### PR TITLE
Update package name for webpub-manifest-parser

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -42,6 +42,7 @@ money==1.3.0
 nameparser==1.0.6
 # nltk is a textblob dependency.
 nltk==3.4.5
+palace-webpub-manifest-parser==1.0.0
 Pillow==6.2.2
 py-bcrypt==0.4
 pymarc==3.2.0
@@ -65,7 +66,6 @@ watchtower==0.8.0
 Werkzeug==1.0.1
 
 multipledispatch==0.6.0
-webpub-manifest-parser
 
 # Theses dependencies are only used in our tests. Ideally they would get moved out to
 # the dev requirements file, but the mock classes for our tests are included alongside


### PR DESCRIPTION
Use the new Palace repo for `webpub-manifest-parser` located here:
https://github.com/ThePalaceProject/webpub-manifest-parser