### PR TITLE
Tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands_pre =
     python -m textblob.download_corpora
 commands =
     pytest {posargs:--disable-warnings tests}
-passenv = SIMPLIFIED_*
+passenv = SIMPLIFIED_* CI
 setenv =
     docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9002/simplified_circulation_test
     docker: SIMPLIFIED_TEST_ELASTICSEARCH=http://localhost:9003

--- a/tox.ini
+++ b/tox.ini
@@ -5,49 +5,49 @@ skipsdist = true
 [testenv]
 deps = -r requirements-dev.txt
 commands_pre =
-    docker: docker exec es elasticsearch-plugin -s install analysis-icu
-    docker: docker restart es
+    docker: docker exec es-core elasticsearch-plugin -s install analysis-icu
+    docker: docker restart es-core
     python -m textblob.download_corpora
 commands =
-    pytest {posargs:--disable-warnings -v tests}
+    pytest {posargs:--disable-warnings tests}
 passenv = SIMPLIFIED_*
 setenv =
-    docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9005/simplified_circulation_test
-    docker: SIMPLIFIED_TEST_ELASTICSEARCH=http://localhost:9006
-    docker: SIMPLIFIED_TEST_MINIO_ENDPOINT_URL=http://localhost:9007
+    docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9002/simplified_circulation_test
+    docker: SIMPLIFIED_TEST_ELASTICSEARCH=http://localhost:9003
+    docker: SIMPLIFIED_TEST_MINIO_ENDPOINT_URL=http://localhost:9004
     docker: SIMPLIFIED_TEST_MINIO_USER=simplified
     docker: SIMPLIFIED_TEST_MINIO_PASSWORD=12345678901234567890
 docker =
-    docker: es
-    docker: db
-    docker: minio
+    docker: es-core
+    docker: db-core
+    docker: minio-core
 allowlist_externals =
     docker: docker
     python
 
-[docker:db]
+[docker:db-core]
 image = postgres:12
 environment =
     POSTGRES_USER=simplified_test
     POSTGRES_PASSWORD=test
     POSTGRES_DB=simplified_circulation_test
 ports =
-    9005:5432/tcp
+    9002:5432/tcp
 
-[docker:es]
+[docker:es-core]
 image = elasticsearch:6.8.6
 environment =
     discovery.type=single-node
 ports =
-    9006:9200/tcp
+    9003:9200/tcp
 
-[docker:minio]
+[docker:minio-core]
 image = bitnami/minio:latest
 environment =
     MINIO_ACCESS_KEY=simplified
     MINIO_SECRET_KEY=12345678901234567890
 ports =
-    9007:9000/tcp
+    9004:9000/tcp
 
 [gh-actions]
 python =


### PR DESCRIPTION
Change the ports and container names in the tox config to allow both the circulation and core to run tox on the same machine at the same time. This is helpful in development, so you can be running both sets of tests simultaneously.

Also make a couple more small changes to the default tox config:
- Pass the `CI` environment variable into the process
- Don't set verbose output