### PR TITLE
Clean orphan external links while deleting a collection

### DIFF
--- a/model/collection.py
+++ b/model/collection.py
@@ -860,7 +860,7 @@ class Collection(Base, HasFullTableCache):
         # Delete the ExternalIntegration associated with this
         # Collection, assuming it wasn't deleted already.
         if self.external_integration:
-            _db.delete(self.external_integration)
+            self.external_integration.delete()
 
         # Now delete the Collection itself.
         _db.delete(self)

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -537,6 +537,18 @@ class ExternalIntegration(Base, HasFullTableCache):
                 lines.append(explanation)
         return lines
 
+    def delete(self):
+        """Remove an external integration."""
+        _db = Session.object_session(self)
+        qu = _db.query(
+            ExternalIntegrationLink
+        ).filter(
+            ExternalIntegrationLink.external_integration_id == self.id
+        )
+        qu.delete()
+
+        _db.delete(self)
+
 
 class ConfigurationSetting(Base, HasFullTableCache):
     """An extra piece of site configuration.

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -19,7 +19,7 @@ from ...model.complaint import Complaint
 from ...model.configuration import (
     ConfigurationSetting,
     ExternalIntegration,
-)
+    ExternalIntegrationLink)
 from ...model.customlist import CustomList
 from ...model.datasource import DataSource
 from ...model.edition import Edition
@@ -829,6 +829,17 @@ class TestCollection(DatabaseTest):
         )
         setting2.value = "value2"
 
+        # Also it has links to another independent ExternalIntegration (S3 storage in this case).
+        s3_storage = self._external_integration(
+            ExternalIntegration.S3, ExternalIntegration.STORAGE_GOAL, libraries=[self._default_library]
+        )
+        link1 = self._external_integration_link(
+            integration, self._default_library, s3_storage, ExternalIntegrationLink.PROTECTED_ACCESS_BOOKS
+        )
+        link2 = self._external_integration_link(
+            integration, self._default_library, s3_storage, ExternalIntegrationLink.COVERS
+        )
+
         # It's got a Work that has a LicensePool, which has a License,
         # which has a loan.
         work = self._work(with_license_pool=True)
@@ -908,11 +919,18 @@ class TestCollection(DatabaseTest):
         # has any LicensePools), but not the second.
         assert [work] == index.removed
 
-        # The ExternalIntegration and its settings have been deleted.
-        assert integration not in self._db.query(ExternalIntegration).all()
+        # The ExternalIntegration, its settings and links have been deleted.
+        external_integrations = self._db.query(ExternalIntegration).all()
+        assert integration not in external_integrations
+        assert s3_storage in external_integrations
+
         settings = self._db.query(ConfigurationSetting).all()
-        for s in (setting1, setting2):
-            assert s not in settings
+        for setting in (setting1, setting2):
+            assert setting not in settings
+
+        links = self._db.query(ExternalIntegrationLink).all()
+        for link in (link1, link2):
+            assert link not in links
 
         # If no search_index is passed into delete() (the default behavior),
         # we try to instantiate the normal ExternalSearchIndex object. Since

--- a/tests/models/test_configuration.py
+++ b/tests/models/test_configuration.py
@@ -444,6 +444,7 @@ class TestExternalIntegrationLink(DatabaseTest):
         assert len(external_integration_links) == 1
         assert external_integration_links[0].other_integration_id == storage2.id
 
+
 class TestExternalIntegration(DatabaseTest):
 
     def setup_method(self):
@@ -647,6 +648,37 @@ username='someuser'""" % integration.id
         # Must be the same value if set
         integration.custom_accept_header = "custom header"
         assert integration.custom_accept_header == "custom header"
+
+    def test_delete(self):
+        """Ensure that ExternalIntegration.delete clears all orphan ExternalIntegrationLinks."""
+        integration1 = self._external_integration(
+            ExternalIntegration.MANUAL, ExternalIntegration.LICENSE_GOAL, libraries=[self._default_library]
+        )
+        integration2 = self._external_integration(
+            ExternalIntegration.S3, ExternalIntegration.STORAGE_GOAL, libraries=[self._default_library]
+        )
+
+        # Set up a a link associating integration2 with integration1.
+        link1 = self._external_integration_link(
+            integration1, self._default_library, integration2, ExternalIntegrationLink.PROTECTED_ACCESS_BOOKS
+        )
+        link2 = self._external_integration_link(
+            integration1, self._default_library, integration2, ExternalIntegrationLink.COVERS
+        )
+
+        # Delete integration1.
+        integration1.delete()
+
+        # Ensure that there are no orphan links.
+        links = self._db.query(ExternalIntegrationLink).all()
+        for link in (link1, link2):
+            assert link not in links
+
+        # Ensure that the first integration was successfully removed.
+        external_integrations = self._db.query(ExternalIntegration).all()
+        assert integration1 not in external_integrations
+        assert integration2 in external_integrations
+
 
 SETTING1_KEY = 'setting1'
 SETTING1_LABEL = 'Setting 1\'s label'


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Currently `database_reaper` fails to remove a collection that has external links to other services (for example, S3 storage).
This PR adds code to fix this issue and clean orphan external links while deleting a collection.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The issue can be reproduced using the following steps:
1. Create an S3 storage service with OA bucket.
2. Create a Manual import collection and associate an OA bucket with it.
3. Mark the collection as deleted in the CM's admin UI.
4. Run `database_reaper` script.

**NOTE:** `ExternalIntegration.links` relationship already declares cascade behaviour:
```python
    links = relationship(
        "ExternalIntegrationLink",
        backref="other_integration",
        foreign_keys="ExternalIntegrationLink.other_integration_id",
        cascade="all, delete-orphan"
    )
```
However, this relationship is associated with the only one side of `ExternalIntegrationLink` - it returns links for child integrations only. For example, in the example above this property will not be empty for the S3 storage and will return an empty list for the collection.

The other way to fix this issue would be to add another relationship covering the other side of `ExternalIntegrationLink`:
```python
    links = relationship(
        "ExternalIntegrationLink",
        backref="integration",
        foreign_keys="ExternalIntegrationLink.external_integration_id",
        cascade="all, delete-orphan"
    )

    other_links = relationship(
        "ExternalIntegrationLink",
        backref="other_integration",
        foreign_keys="ExternalIntegrationLink.other_integration_id",
        cascade="all, delete-orphan"
    )
```

You can find this solution in this [PR](https://github.com/ThePalaceProject/circulation-core/pull/18).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
