### PR TITLE
Move common functionality from TestOPDS2Importer to OPDS2Test

### DIFF
--- a/tests/test_opds2_import.py
+++ b/tests/test_opds2_import.py
@@ -19,7 +19,7 @@ from ..opds2_import import OPDS2Importer, RWPMManifestParser
 from .test_opds_import import OPDSTest
 
 
-class TestOPDS2Importer(OPDSTest):
+class OPDS2Test(OPDSTest):
     @staticmethod
     def _get_edition_by_identifier(editions, identifier):
         """Find an edition in the list by its identifier.
@@ -68,6 +68,8 @@ class TestOPDS2Importer(OPDSTest):
 
         return None
 
+
+class TestOPDS2Importer(OPDS2Test):
     def sample_opds(self, filename, file_type="r"):
         base_path = os.path.split(__file__)[0]
         resource_path = os.path.join(base_path, "files", "opds2")


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PRs moves common functionality from TestOPDS2Importer to OPDS2Test to reuse it in `TestODL2Importer` in https://github.com/ThePalaceProject/circulation/pull/25.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
