### PR TITLE
Update upstream sync action

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,34 +5,35 @@ on:
 
   workflow_dispatch:
 
-
 jobs:
   sync_with_nypl:
     runs-on: ubuntu-latest
 
     env:
-      REMOTE_ORG: NYPL-Simplified
-      REMOTE_REPO: server_core
-      REMOTE_BRANCH: develop
-      LOCAL_BRANCH: nypl/develop
+      UPSTREAM_ORG: NYPL-Simplified
+      UPSTREAM_REPO: server_core
+      UPSTREAM_BRANCH: develop
+      ORIGIN_BRANCH: nypl/develop
 
     steps:
-    - name: Checkout local branch
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ env.LOCAL_BRANCH }}
-
-    - name: Fetch remote repo
-      id: fetch
-      run: |
-        git remote add upstream https://github.com/${{ env.REMOTE_ORG }}/${{ env.REMOTE_REPO }}.git
-        git fetch upstream ${{ env.REMOTE_BRANCH }}
-        echo "::set-output name=LOCAL_COMMIT::$(git rev-parse refs/heads/${{ env.LOCAL_BRANCH }})"
-        echo "::set-output name=REMOTE_COMMIT::$(git rev-parse refs/remotes/upstream/${{ env.REMOTE_BRANCH }})"
-
-    - name: Sync
-      if: steps.fetch.outputs.LOCAL_COMMIT != steps.fetch.outputs.REMOTE_COMMIT
-      run: |
-        git pull --no-edit --ff-only upstream ${{ env.REMOTE_BRANCH }}
-        git push origin ${{ env.LOCAL_BRANCH }}
-
+      - name: Checkout repo to sync
+        uses: actions/checkout@v2
+        with:
+          path: code
+          
+      - name: Checkout CI scripts
+        uses: actions/checkout@v2
+        with:
+          repository: 'ThePalaceProject/ci-scripts'
+          path: ci
+          
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          
+      - name: Install Python requirements
+        run: pip install -r ci/sync-requirements.txt
+        
+      - name: Sync branch with upstream
+        run: python ci/sync.py code


### PR DESCRIPTION
## Description

Update the code sync workflow to use a python script located in the [CI-Scripts](https://github.com/ThePalaceProject/ci-scripts) repo that we can share across all the code we would like to sync in our organization.

Using an external python script lets us more gracefully handle possible problems with the sync, like the local or remote branches not existing.

This updates the sync action in this repo to match https://github.com/ThePalaceProject/library-registry/pull/22