### PR TITLE
Do not fail while importing OPDS 2.x \ ODL 2.x publications with incorrect identifiers

### DIFF
--- a/opds_import.py
+++ b/opds_import.py
@@ -62,11 +62,15 @@ def parse_identifier(db, identifier):
     :type identifier: str
 
     :return: Identifier object
-    :rtype: core.model.identifier.Identifier
+    :rtype: Optional[core.model.identifier.Identifier]
     """
-    identifier, _ = Identifier.parse_urn(db, identifier)
+    parsed_identifier = None
+    result = Identifier.parse_urn(db, identifier)
 
-    return identifier
+    if result is not None:
+        parsed_identifier, _ = result
+
+    return parsed_identifier
 
 
 class AccessNotAuthenticated(Exception):

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -45,8 +45,8 @@ py-bcrypt==0.4
 pymarc==4.0.0
 pyparsing==2.4.7
 pyspellchecker==0.5.5
-python-dateutil==2.8.1
-pytz==2020.1
+python-dateutil==2.8.2
+pytz==2021.1
 rdflib==5.0.0
 requests==2.24.0
 requests-futures==1.0.0
@@ -62,7 +62,7 @@ watchtower==0.8.0
 Werkzeug==1.0.1
 
 multipledispatch==0.6.0
-palace-webpub-manifest-parser==2.0.1
+palace-webpub-manifest-parser==2.0.3
 
 # Theses dependencies are only used in our tests. Ideally they would get moved out to
 # the dev requirements file, but the mock classes for our tests are included alongside


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR fixes the OPDS 2.x \ ODL 2.x importer to not fail while importing publications with incorrect identifiers.
Please note that the logic for filtering out non-ISBN identifiers is currently hard coded. In the next PR I'll add a new configuration setting allowing to select identifier types that should be imported.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
