### PR TITLE
Fix date & time comparison in the OPDS 1.x importer

### DIFF
--- a/opds_import.py
+++ b/opds_import.py
@@ -49,7 +49,7 @@ from .util.http import HTTP, BadResponseException
 from .util.opds_writer import OPDSFeed, OPDSMessage
 from .util.string_helpers import base64
 from .util.xmlparser import XMLParser
-from .util.datetime_helpers import datetime_utc, utc_now
+from .util.datetime_helpers import datetime_utc, utc_now, to_utc
 
 
 def parse_identifier(db, identifier):
@@ -2016,7 +2016,7 @@ class OPDSImportMonitor(CollectionMonitor, HasSelfTests):
                 )
                 return True
 
-            if last_updated_remote >= record.timestamp:
+            if to_utc(last_updated_remote) >= to_utc(record.timestamp):
                 # This book has been updated.
                 self.log.info(
                     "Counting %s as new because its coverage date is %s and remote has %s.",


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR fixes date & time comparison in the OPDS 1.x importer to ensure that date & time values are always transformed to UTC before comparing to each other.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
