### PR TITLE
Add a configuration setting allowing to restrict supported identifier types

### DIFF
--- a/model/constants.py
+++ b/model/constants.py
@@ -4,6 +4,8 @@
 
 import re
 from collections import OrderedDict
+from enum import Enum
+
 
 class DataSourceConstants(object):
     GUTENBERG = "Gutenberg"
@@ -182,6 +184,30 @@ class IdentifierConstants(object):
     IDEAL_COVER_ASPECT_RATIO = 2.0/3
     IDEAL_IMAGE_HEIGHT = 240
     IDEAL_IMAGE_WIDTH = 160
+
+
+class IdentifierType(Enum):
+    """Enumeration of all available identifier types."""
+    OVERDRIVE_ID = IdentifierConstants.OVERDRIVE_ID
+    ODILO_ID = IdentifierConstants.ODILO_ID
+    BIBLIOTHECA_ID = IdentifierConstants.BIBLIOTHECA_ID
+    GUTENBERG_ID = IdentifierConstants.GUTENBERG_ID
+    AXIS_360_ID = IdentifierConstants.AXIS_360_ID
+    ELIB_ID = IdentifierConstants.ELIB_ID
+    ASIN = IdentifierConstants.ASIN
+    ISBN = IdentifierConstants.ISBN
+    NOVELIST_ID = IdentifierConstants.NOVELIST_ID
+    OCLC_WORK = IdentifierConstants.OCLC_WORK
+    OCLC_NUMBER = IdentifierConstants.OCLC_NUMBER
+    OPEN_LIBRARY_ID = IdentifierConstants.OPEN_LIBRARY_ID
+    BIBLIOCOMMONS_ID = IdentifierConstants.BIBLIOCOMMONS_ID
+    URI = IdentifierConstants.URI
+    DOI = IdentifierConstants.DOI
+    UPC = IdentifierConstants.UPC
+    BIBBLIO_CONTENT_ITEM_ID = IdentifierConstants.BIBBLIO_CONTENT_ITEM_ID
+    ENKI_ID = IdentifierConstants.ENKI_ID
+    SUDOC_CALL_NUMBER = IdentifierConstants.SUDOC_CALL_NUMBER
+    PROQUEST_ID = IdentifierConstants.PROQUEST_ID
 
 
 class LinkRelations(object):

--- a/opds_import.py
+++ b/opds_import.py
@@ -1952,16 +1952,17 @@ class OPDSImportMonitor(CollectionMonitor, HasSelfTests):
         last_update_dates = self.importer.extract_last_update_dates(feed)
 
         new_data = False
-        for identifier, remote_updated in last_update_dates:
+        for raw_identifier, remote_updated in last_update_dates:
 
-            identifier = self._parse_identifier(identifier)
+            identifier = self._parse_identifier(raw_identifier)
             if not identifier:
                 # Maybe this is new, maybe not, but we can't associate
                 # the information with an Identifier, so we can't do
                 # anything about it.
-                self.log.info(
-                    "Ignoring %s because unable to turn into an Identifier."
-                )
+                if raw_identifier:
+                    self.log.info(
+                        f"Ignoring {raw_identifier} because unable to turn into an Identifier."
+                    )
                 continue
 
             if self.identifier_needs_import(identifier, remote_updated):

--- a/tests/files/opds2/feed.json
+++ b/tests/files/opds2/feed.json
@@ -75,7 +75,7 @@
             "name": "Samuel Langhorne Clemens"
           }
         ],
-        "identifier": "urn:isbn:9781234567897",
+        "identifier": "http://example.org/huckleberry-finn",
         "language": [
           "eng"
         ],

--- a/tests/test_opds2_import.py
+++ b/tests/test_opds2_import.py
@@ -5,6 +5,7 @@ from parameterized import parameterized
 from webpub_manifest_parser.opds2 import OPDS2FeedParserFactory
 
 from ..model import (
+    Collection,
     Contribution,
     Contributor,
     DataSource,
@@ -15,7 +16,9 @@ from ..model import (
     MediaTypes,
     Work,
 )
-from ..opds2_import import OPDS2Importer, RWPMManifestParser
+from ..model.configuration import ConfigurationFactory, ConfigurationStorage
+from ..model.constants import IdentifierType
+from ..opds2_import import OPDS2Importer, OPDS2ImporterConfiguration, RWPMManifestParser
 from .test_opds_import import OPDSTest
 
 
@@ -70,10 +73,37 @@ class OPDS2Test(OPDSTest):
 
 
 class TestOPDS2Importer(OPDS2Test):
-    def sample_opds(self, filename, file_type="r"):
+    MOBY_DICK_IDENTIFIER = "urn:isbn:978-3-16-148410-0"
+    HUCKLEBERRY_FINN_IDENTIFIER = "http://example.org/huckleberry-finn"
+
+    def sample_opds(self, filename: str, file_mode: str = "r") -> str:
+        """Return a string containing an OPDS 2.x feed from the specified file.
+
+        :param filename: File containing the OPDS 2.x feed
+        :param file_mode: File mode
+        """
         base_path = os.path.split(__file__)[0]
         resource_path = os.path.join(base_path, "files", "opds2")
+
         return open(os.path.join(resource_path, filename)).read()
+
+    def setup_method(self):
+        super(TestOPDS2Importer, self).setup_method()
+
+        self._collection: Collection = self._default_collection
+        self._data_source: DataSource = DataSource.lookup(
+            self._db, "OPDS 2.0 Data Source", autocreate=True
+        )
+
+        self._collection.data_source = self._data_source
+
+        self._importer: OPDS2Importer = OPDS2Importer(
+            self._db, self._collection, RWPMManifestParser(OPDS2FeedParserFactory())
+        )
+        self._configuration_storage: ConfigurationStorage = ConfigurationStorage(
+            self._importer
+        )
+        self._configuration_factory: ConfigurationFactory = ConfigurationFactory()
 
     @parameterized.expand(
         [
@@ -81,25 +111,21 @@ class TestOPDS2Importer(OPDS2Test):
             ("manifest encoded as a byte-string", "bytes"),
         ]
     )
-    def test(self, _, manifest_type):
+    def test_opds2_importer_correctly_imports_valid_opds2_feed(
+        self, _, manifest_type: str
+    ) -> None:
+        """Ensure that OPDS2Importer correctly imports valid OPDS 2.x feeds.
+
+        :param manifest_type: Manifest's type: string or binary
+        """
         # Arrange
-        collection = self._default_collection
-        data_source = DataSource.lookup(
-            self._db, "OPDS 2.0 Data Source", autocreate=True
-        )
-
-        collection.data_source = data_source
-
-        importer = OPDS2Importer(
-            self._db, collection, RWPMManifestParser(OPDS2FeedParserFactory())
-        )
         content_server_feed = self.sample_opds("feed.json")
 
         if manifest_type == "bytes":
             content_server_feed = content_server_feed.encode()
 
         # Act
-        imported_editions, pools, works, failures = importer.import_from_feed(
+        imported_editions, pools, works, failures = self._importer.import_from_feed(
             content_server_feed
         )
 
@@ -111,7 +137,7 @@ class TestOPDS2Importer(OPDS2Test):
 
         # 1.1. Edition with open-access links (Moby-Dick)
         moby_dick_edition = self._get_edition_by_identifier(
-            imported_editions, "urn:isbn:978-3-16-148410-0"
+            imported_editions, self.MOBY_DICK_IDENTIFIER
         )
         assert isinstance(moby_dick_edition, Edition)
 
@@ -134,7 +160,7 @@ class TestOPDS2Importer(OPDS2Test):
         assert moby_dick_edition == moby_dick_author_contribution.edition
         assert Contributor.AUTHOR_ROLE == moby_dick_author_contribution.role
 
-        assert data_source == moby_dick_edition.data_source
+        assert self._data_source == moby_dick_edition.data_source
 
         assert "Test Publisher" == moby_dick_edition.publisher
         assert datetime.date(2015, 9, 29) == moby_dick_edition.published
@@ -147,7 +173,7 @@ class TestOPDS2Importer(OPDS2Test):
 
         # 1.2. Edition with non open-access acquisition links (Adventures of Huckleberry Finn)
         huckleberry_finn_edition = self._get_edition_by_identifier(
-            imported_editions, "urn:isbn:9781234567897"
+            imported_editions, self.HUCKLEBERRY_FINN_IDENTIFIER
         )
         assert isinstance(huckleberry_finn_edition, Edition)
 
@@ -191,7 +217,7 @@ class TestOPDS2Importer(OPDS2Test):
         assert huckleberry_finn_edition == huckleberry_finn_author_contribution.edition
         assert Contributor.AUTHOR_ROLE == huckleberry_finn_author_contribution.role
 
-        assert data_source == huckleberry_finn_edition.data_source
+        assert self._data_source == huckleberry_finn_edition.data_source
 
         assert "Test Publisher" == huckleberry_finn_edition.publisher
         assert datetime.date(2014, 9, 28) == huckleberry_finn_edition.published
@@ -204,7 +230,7 @@ class TestOPDS2Importer(OPDS2Test):
 
         # 2.1. Edition with open-access links (Moby-Dick)
         moby_dick_license_pool = self._get_license_pool_by_identifier(
-            pools, "urn:isbn:978-3-16-148410-0"
+            pools, self.MOBY_DICK_IDENTIFIER
         )
         assert isinstance(moby_dick_license_pool, LicensePool)
         assert moby_dick_license_pool.open_access
@@ -224,7 +250,7 @@ class TestOPDS2Importer(OPDS2Test):
 
         # 2.2. Edition with non open-access acquisition links (Adventures of Huckleberry Finn)
         huckleberry_finn_license_pool = self._get_license_pool_by_identifier(
-            pools, "urn:isbn:9781234567897"
+            pools, self.HUCKLEBERRY_FINN_IDENTIFIER
         )
         assert isinstance(huckleberry_finn_license_pool, LicensePool)
         assert not huckleberry_finn_license_pool.open_access
@@ -264,17 +290,15 @@ class TestOPDS2Importer(OPDS2Test):
         assert 2 == len(works)
 
         # 3.1. Edition with open-access links (Moby-Dick)
-        moby_dick_work = self._get_work_by_identifier(
-            works, "urn:isbn:978-3-16-148410-0"
-        )
+        moby_dick_work = self._get_work_by_identifier(works, self.MOBY_DICK_IDENTIFIER)
         assert isinstance(moby_dick_work, Work)
         assert moby_dick_edition == moby_dick_work.presentation_edition
         assert 1 == len(moby_dick_work.license_pools)
         assert moby_dick_license_pool == moby_dick_work.license_pools[0]
 
-        # 3.2. Edition with open-access links (Moby-Dick)
+        # 3.2. Edition without open-access links (Adventures of Huckleberry Finn)
         huckleberry_finn_work = self._get_work_by_identifier(
-            works, "urn:isbn:9781234567897"
+            works, self.HUCKLEBERRY_FINN_IDENTIFIER
         )
         assert isinstance(huckleberry_finn_work, Work)
         assert huckleberry_finn_edition == huckleberry_finn_work.presentation_edition
@@ -285,3 +309,45 @@ class TestOPDS2Importer(OPDS2Test):
             "December 1884 and in the United States in February 1885."
             == huckleberry_finn_work.summary_text
         )
+
+    @parameterized.expand(
+        [
+            ("ISBN", IdentifierType.ISBN, MOBY_DICK_IDENTIFIER),
+            ("URI", IdentifierType.URI, HUCKLEBERRY_FINN_IDENTIFIER),
+        ]
+    )
+    def test_opds2_importer_skips_publications_with_unsupported_identifier_types(
+        self, _, identifier_type: IdentifierType, identifier: str
+    ) -> None:
+        """Ensure that OPDS2Importer imports only publications having supported identifier types.
+
+        This test imports the feed consisting of two publications,
+        each having a different identifier type: ISBN and URI.
+
+        First, it tries to import the feed marking ISBN as the only supported identifier type. Secondly, it uses URI.
+        Each time it checks that CM imported only the publication having the selected identifier type.
+        """
+        # Arrange
+        # Update the list of supported identifier types in the collection's configuration settings
+        # and set the identifier type passed as a parameter as the only supported identifier type.
+        with self._configuration_factory.create(
+            self._configuration_storage, self._db, OPDS2ImporterConfiguration
+        ) as configuration:
+            configuration.set_supported_identifier_types([identifier_type])
+
+        content_server_feed = self.sample_opds("feed.json")
+
+        # Act
+        imported_editions, pools, works, failures = self._importer.import_from_feed(
+            content_server_feed
+        )
+
+        # Assert
+
+        # Ensure that that CM imported only the edition having the selected identifier type.
+        assert isinstance(imported_editions, list)
+        assert 1 == len(imported_editions)
+
+        # Ensure that it was parsed correctly and available by its identifier.
+        edition = self._get_edition_by_identifier(imported_editions, identifier)
+        assert edition is not None


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds a configuration setting allowing to restrict supported identifier types for OPDS 2.x collections:
![image](https://user-images.githubusercontent.com/6442436/132552452-692cac53-a268-4f9a-9ace-e1f8f3452386.png)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
