### PR TITLE
Add support for DeMarque LCP content

### DIFF
--- a/model/configuration.py
+++ b/model/configuration.py
@@ -165,6 +165,8 @@ class ExternalIntegration(Base, HasFullTableCache):
     OPDS_FOR_DISTRIBUTORS = 'OPDS for Distributors'
     ENKI = DataSourceConstants.ENKI
     FEEDBOOKS = DataSourceConstants.FEEDBOOKS
+    ODL = "ODL"
+    ODL2 = "ODL 2.0"
     LCP = DataSourceConstants.LCP
     MANUAL = DataSourceConstants.MANUAL
     PROQUEST = DataSourceConstants.PROQUEST


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds additional code to support the [Readium LCP Automatic Key Retrieval feature](https://readium.org/lcp-specs/notes/lcp-key-retrieval.html) for ODL 1.x\ODL 2.x collections.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
