### PR TITLE
Update urllib3 version to address CVE-2021-33503

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -11,7 +11,7 @@
 Babel==2.9.1
 boto3<1.19
 botocore<1.22
-certifi==2020.6.20
+certifi
 chardet==3.0.4
 click==7.1.2
 elasticsearch<6.9


### PR DESCRIPTION
This PR addresses the security issue CVE-2021-33503 that dependabot is warning about. Newer versions of urllib3 do cause issues with Axis360 though, this is addressed in the linked PR.