### PR TITLE
Sort Work objects returned by Work.missing_coverage_from by ID to eliminate dabatase deadlocks

### DIFF
--- a/model/work.py
+++ b/model/work.py
@@ -331,7 +331,7 @@ class Work(Base):
             Work.id == WorkCoverageRecord.work_id,
             WorkCoverageRecord.operation == operation,
         )
-        q = _db.query(Work).outerjoin(WorkCoverageRecord, clause)
+        q = _db.query(Work).outerjoin(WorkCoverageRecord, clause).order_by(Work.id)
 
         missing = WorkCoverageRecord.not_covered(
             count_as_covered, count_as_missing_before

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -973,6 +973,23 @@ class TestWork(DatabaseTest):
             self._db, operation, count_as_missing_before=cutoff
         ).all()
 
+    def test_missing_coverage_from_sorts_results(self):
+        """Ensure that Work objects returned by Work.missing_coverage_from are sorted by their identifier."""
+        operation = "the_operation"
+
+        # Create two Work objects.
+        work1 = self._work(with_license_pool=True)
+        work2 = self._work(with_license_pool=True)
+        works = [work1, work2]
+
+        self._db.commit()
+
+        # Sort the objects by their id.
+        works.sort(key=lambda work: work.id)
+
+        # Ensure that the Work objects returned by Work.missing_coverage_from are sorted.
+        assert works == Work.missing_coverage_from(self._db, operation).all()
+
     def test_top_genre(self):
         work = self._work()
         identifier = work.presentation_edition.primary_identifier


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR eliminates dabatase deadlocks by sorting `Work` objects returned by Work.missing_coverage_from by their ID.

The deadlock happens when Circulation Manager runs multiple monitors at the same time. Without explicit sorting CM `Work` objects in almost _random order_. While it processes `Work` objects CM updates corresponding `WorkCoverageRecord` objects. Since `Work` objects are fetched in _random order_, `WorkCoverageRecord` objects are also in _random order_. It means that sometimes CM processes them in the opposite order.
For example:

1. **Monitor 1** fetches `Work` objects # 1 and 2.
2. **Monitor 2** fetches `Work` objects # 2 and 1.
3. **Monitor 1** updates `Work` object # 1, **Monitor 2** updates `Work` object # 2.
4. **Monitor 1** tries to update `Work` object # 2 but it cannot - it's locked because it's getting updated in a separate transaction by **Monitor 2**. **Monitor 2** tries to update `Work` object # 1 but it also can't do it because it locked by **Monitor 1**. The deadlock happens.

Here is another description of this case (I took it from [this article](https://www.cybertec-postgresql.com/en/postgresql-understanding-deadlocks/)):
![image](https://user-images.githubusercontent.com/6442436/139307696-64e7440d-a262-4f57-8677-0466c9067817.png)


Below is the stacktrace found in the logs after the deadlock had happened:
```
"Traceback (most recent call last):
  File \"/var/www/circulation/core/scripts.py\", line 280, in do_run
    monitor.run()
  File \"/var/www/circulation/core/monitor.py\", line 221, in run
    self._db.commit()
  File \"/var/www/circulation/env/lib/python3.6/site-packages/sqlalchemy/orm/session.py\", line 1042, in commit
    self.transaction.commit()
  File \"/var/www/circulation/env/lib/python3.6/site-packages/sqlalchemy/orm/session.py\", line 502, in commit
    self._assert_active(prepared_ok=True)
  File \"/var/www/circulation/env/lib/python3.6/site-packages/sqlalchemy/orm/session.py\", line 296, in _assert_active
    code=\"7s2a\",\nsqlalchemy.exc.InvalidRequestError: This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely)
(psycopg2.errors.DeadlockDetected) deadlock detected\nDETAIL:  Process 10975 waits for ShareLock on transaction 23144667; blocked by process 6947.\nProcess 6947 waits for ShareLock on transaction 23144173; blocked by process 10975.\nHINT:  See server log for query details.\nCONTEXT:  while updating tuple (7226,37) in relation \"workcoveragerecords\"

[SQL: UPDATE workcoveragerecords SET timestamp=%(timestamp)s WHERE workcoveragerecords.id = %(workcoveragerecords_id)s]
[parameters: {'timestamp': datetime.datetime(2021, 10, 21, 20, 12, 19, 153698, tzinfo=\u003cUTC\u003e), 'workcoveragerecords_id': 1060095}]
(Background on this error at: http://sqlalche.me/e/13/e3q8) (Background on this error at: http://sqlalche.me/e/13/7s2a)
\nDuring handling of the above exception, another exception occurred:
\nTraceback (most recent call last):
  File \"/var/www/circulation/core/scripts.py\", line 159, in run
    timestamp_data = self.do_run()
  File \"/var/www/circulation/core/scripts.py\", line 284, in do_run
    if monitor.collection:
  File \"/var/www/circulation/core/monitor.py\", line 129, in collection
    return get_one(self._db, Collection, id=self.collection_id)
  File \"/var/www/circulation/core/model/__init__.py\", line 90, in get_one
    return q.one()
  File \"/var/www/circulation/env/lib/python3.6/site-packages/sqlalchemy/orm/query.py\", line 3463, in one
    ret = self.one_or_none()
  File \"/var/www/circulation/env/lib/python3.6/site-packages/sqlalchemy/orm/query.py\", line 3432, in one_or_none
    ret = list(self)
  File \"/var/www/circulation/env/lib/python3.6/site-packages/sqlalchemy/orm/query.py\", line 3507, in __iter__
    self.session._autoflush()
  File \"/var/www/circulation/env/lib/python3.6/site-packages/sqlalchemy/orm/session.py\", line 1617, in _autoflush
    self.flush()
  File \"/var/www/circulation/env/lib/python3.6/site-packages/sqlalchemy/orm/session.py\", line 2523, in flush
    self._flush(objects)
  File \"/var/www/circulation/env/lib/python3.6/site-packages/sqlalchemy/orm/session.py\", line 2619, in _flush
    subtransactions=True
  File \"/var/www/circulation/env/lib/python3.6/site-packages/sqlalchemy/orm/session.py\", line 953, in begin
    self.transaction = self.transaction._begin(nested=nested)
  File \"/var/www/circulation/env/lib/python3.6/site-packages/sqlalchemy/orm/session.py\", line 317, in _begin
    self._assert_active()
  File \"/var/www/circulation/env/lib/python3.6/site-packages/sqlalchemy/orm/session.py\", line 296, in _assert_active
    code=\"7s2a\",\nsqlalchemy.exc.InvalidRequestError: This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely)
(psycopg2.errors.DeadlockDetected) deadlock detected\nDETAIL:  Process 10975 waits for ShareLock on transaction 23144667; blocked by process 6947.\nProcess 6947 waits for ShareLock on transaction 23144173; blocked by process 10975.\nHINT:  See server log for query details.\nCONTEXT:  while updating tuple (7226,37) in relation \"workcoveragerecords\"

[SQL: UPDATE workcoveragerecords SET timestamp=%(timestamp)s WHERE workcoveragerecords.id = %(workcoveragerecords_id)s]
[parameters: {'timestamp': datetime.datetime(2021, 10, 21, 20, 12, 19, 153698, tzinfo=\u003cUTC\u003e), 'workcoveragerecords_id': 1060095}]
(Background on this error at: http://sqlalche.me/e/13/e3q8) (Background on this error at: http://sqlalche.me/e/13/7s2a)"
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
