### PR TITLE
Make ConfigurationMetadata's getter load the default value when no value is set

### DIFF
--- a/model/configuration.py
+++ b/model/configuration.py
@@ -1178,7 +1178,10 @@ class ConfigurationMetadata(object):
         else:
             # LIST and MENU configuration settings are stored as JSON-serialized lists in the database.
             # We need to deserialize them to get actual values.
-            if self.type in (ConfigurationAttributeType.LIST, ConfigurationAttributeType.MENU):
+            if self.type in (
+                ConfigurationAttributeType.LIST,
+                ConfigurationAttributeType.MENU,
+            ):
                 if isinstance(setting_value, str):
                     setting_value = json.loads(setting_value)
                 else:

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -1175,6 +1175,21 @@ class ConfigurationMetadata(object):
 
         if setting_value is None:
             setting_value = self.default
+        else:
+            # LIST and MENU configuration settings are stored as JSON-serialized lists in the database.
+            # We need to deserialize them to get actual values.
+            if self.type in (ConfigurationAttributeType.LIST, ConfigurationAttributeType.MENU):
+                if isinstance(setting_value, str):
+                    setting_value = json.loads(setting_value)
+                else:
+                    # We assume that LIST and MENU values can be either JSON or empty.
+                    if setting_value is not None:
+                        raise ValueError(
+                            f"{self._type} configuration setting '{self._key}' has an incorrect format. "
+                            f"Expected JSON-serialized list but got {setting_value}."
+                        )
+
+                    setting_value = []
 
         return setting_value
 

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -1171,7 +1171,12 @@ class ConfigurationMetadata(object):
                 "owner must be an instance of ConfigurationSettingsMetadataOwner type"
             )
 
-        return owner_instance.get_setting_value(self._key)
+        setting_value = owner_instance.get_setting_value(self._key)
+
+        if setting_value is None:
+            setting_value = self.default
+
+        return setting_value
 
     def __set__(self, owner_instance, value):
         """Updates the setting's value

--- a/tests/models/test_configuration.py
+++ b/tests/models/test_configuration.py
@@ -874,6 +874,19 @@ class TestConfigurationGrouping(object):
         assert setting_value == expected_value
         configuration_storage.load.assert_called_once_with(db, setting_name)
 
+    def test_getter_return_default_value(self):
+        # Arrange
+        configuration_storage = create_autospec(spec=ConfigurationStorage)
+        configuration_storage.load = MagicMock(return_value=None)
+        db = create_autospec(spec=sqlalchemy.orm.session.Session)
+        configuration = TestConfiguration(configuration_storage, db)
+
+        # Act
+        setting_value = configuration.setting1
+
+        # Assert
+        assert SETTING1_DEFAULT == setting_value
+
     @parameterized.expand(
         [("setting1", "setting1", 12345), ("setting2", "setting2", "12345")]
     )

--- a/tests/models/test_configuration.py
+++ b/tests/models/test_configuration.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+import json
 from enum import Enum
 
 import pytest
@@ -762,10 +763,33 @@ SETTING2_OPTIONS = [
 ]
 SETTING2_CATEGORY = "Settings"
 
+SETTING3_KEY = "setting3"
+SETTING3_LABEL = "Setting 3's label"
+SETTING3_DESCRIPTION = "Setting 3's description"
+SETTING3_TYPE = ConfigurationAttributeType.MENU
+SETTING3_REQUIRED = False
+SETTING3_OPTIONS = [
+    ConfigurationOption("key1", "value1"),
+    ConfigurationOption("key2", "value2"),
+    ConfigurationOption("key3", "value3"),
+]
+SETTING3_DEFAULT = [SETTING3_OPTIONS[0].key, SETTING3_OPTIONS[1].key]
+SETTING3_CATEGORY = "Settings"
+
+
+SETTING4_KEY = "setting4"
+SETTING4_LABEL = "Setting 4's label"
+SETTING4_DESCRIPTION = "Setting 4's description"
+SETTING4_TYPE = ConfigurationAttributeType.LIST
+SETTING4_REQUIRED = False
+SETTING4_OPTIONS = None
+SETTING4_DEFAULT = None
+SETTING4_CATEGORY = "Settings"
+
 
 class TestConfiguration(ConfigurationGrouping):
     setting1 = ConfigurationMetadata(
-        key="setting1",
+        key=SETTING1_KEY,
         label=SETTING1_LABEL,
         description=SETTING1_DESCRIPTION,
         type=SETTING1_TYPE,
@@ -775,7 +799,7 @@ class TestConfiguration(ConfigurationGrouping):
     )
 
     setting2 = ConfigurationMetadata(
-        key="setting2",
+        key=SETTING2_KEY,
         label=SETTING2_LABEL,
         description=SETTING2_DESCRIPTION,
         type=SETTING2_TYPE,
@@ -783,6 +807,28 @@ class TestConfiguration(ConfigurationGrouping):
         default=SETTING2_DEFAULT,
         options=SETTING2_OPTIONS,
         category=SETTING2_CATEGORY,
+    )
+
+    setting3 = ConfigurationMetadata(
+        key=SETTING3_KEY,
+        label=SETTING3_LABEL,
+        description=SETTING3_DESCRIPTION,
+        type=SETTING3_TYPE,
+        required=SETTING3_REQUIRED,
+        default=SETTING3_DEFAULT,
+        options=SETTING3_OPTIONS,
+        category=SETTING3_CATEGORY,
+    )
+
+    setting4 = ConfigurationMetadata(
+        key=SETTING4_KEY,
+        label=SETTING4_LABEL,
+        description=SETTING4_DESCRIPTION,
+        type=SETTING4_TYPE,
+        required=SETTING4_REQUIRED,
+        default=SETTING4_DEFAULT,
+        options=SETTING4_OPTIONS,
+        category=SETTING4_CATEGORY,
     )
 
 
@@ -874,6 +920,56 @@ class TestConfigurationGrouping(object):
         assert setting_value == expected_value
         configuration_storage.load.assert_called_once_with(db, setting_name)
 
+    @parameterized.expand(
+        [
+            (
+                "default_menu_value",
+                TestConfiguration.setting3.key,
+                None,
+                TestConfiguration.setting3.default,
+            ),
+            (
+                "menu_value",
+                TestConfiguration.setting3.key,
+                json.dumps(
+                    [
+                        TestConfiguration.setting3.options[0].key,
+                        TestConfiguration.setting3.options[1].key,
+                    ]
+                ),
+                [
+                    TestConfiguration.setting3.options[0].key,
+                    TestConfiguration.setting3.options[1].key,
+                ],
+            ),
+            (
+                "default_list_value",
+                TestConfiguration.setting4.key,
+                None,
+                TestConfiguration.setting4.default,
+            ),
+            (
+                "menu_value",
+                TestConfiguration.setting4.key,
+                json.dumps(["value1", "value2"]),
+                ["value1", "value2"],
+            ),
+        ]
+    )
+    def test_menu_and_list_getters(self, _, setting_name, db_value, expected_value):
+        # Arrange
+        configuration_storage = create_autospec(spec=ConfigurationStorage)
+        configuration_storage.load = MagicMock(return_value=db_value)
+        db = create_autospec(spec=sqlalchemy.orm.session.Session)
+        configuration = TestConfiguration(configuration_storage, db)
+
+        # Act
+        setting_value = getattr(configuration, setting_name)
+
+        # Assert
+        assert setting_value == expected_value
+        configuration_storage.load.assert_called_once_with(db, setting_name)
+
     def test_getter_return_default_value(self):
         # Arrange
         configuration_storage = create_autospec(spec=ConfigurationStorage)
@@ -910,7 +1006,7 @@ class TestConfigurationGrouping(object):
         settings = TestConfiguration.to_settings()
 
         # Assert
-        assert len(settings) == 2
+        assert len(settings) == 4
 
         assert settings[0][ConfigurationAttribute.KEY.value] == SETTING1_KEY
         assert settings[0][ConfigurationAttribute.LABEL.value] == SETTING1_LABEL
@@ -936,6 +1032,31 @@ class TestConfigurationGrouping(object):
             option.to_settings() for option in SETTING2_OPTIONS
         ]
         assert settings[1][ConfigurationAttribute.CATEGORY.value] == SETTING2_CATEGORY
+
+        assert settings[2][ConfigurationAttribute.KEY.value] == SETTING3_KEY
+        assert settings[2][ConfigurationAttribute.LABEL.value] == SETTING3_LABEL
+        assert (
+            settings[2][ConfigurationAttribute.DESCRIPTION.value]
+            == SETTING3_DESCRIPTION
+        )
+        assert settings[2][ConfigurationAttribute.TYPE.value] == SETTING3_TYPE.value
+        assert settings[2][ConfigurationAttribute.REQUIRED.value] == SETTING3_REQUIRED
+        assert settings[2][ConfigurationAttribute.DEFAULT.value] == SETTING3_DEFAULT
+        assert settings[2][ConfigurationAttribute.OPTIONS.value] == [
+            option.to_settings() for option in SETTING3_OPTIONS
+        ]
+        assert settings[2][ConfigurationAttribute.CATEGORY.value] == SETTING3_CATEGORY
+
+        assert settings[3][ConfigurationAttribute.KEY.value] == SETTING4_KEY
+        assert settings[3][ConfigurationAttribute.LABEL.value] == SETTING4_LABEL
+        assert (
+            settings[3][ConfigurationAttribute.DESCRIPTION.value]
+            == SETTING4_DESCRIPTION
+        )
+        assert settings[3][ConfigurationAttribute.TYPE.value] == SETTING4_TYPE.value
+        assert settings[3][ConfigurationAttribute.REQUIRED.value] == SETTING4_REQUIRED
+        assert settings[3][ConfigurationAttribute.DEFAULT.value] == SETTING4_DEFAULT
+        assert settings[3][ConfigurationAttribute.CATEGORY.value] == SETTING4_CATEGORY
 
     def test_to_settings_considers_explicit_indices(self):
         # Act


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR modifies the configuration framework and makes `ConfigurationMetadata`'s getter return the default value when no value is set.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
