### PR TITLE
Fix license accounting for ODL

### DIFF
--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1063,7 +1063,9 @@ class CirculationData(MetaToModelUtility):
         self.__links = None
         self.links = links
 
-        # Information about individual terms for each license in a pool.
+        # Information about individual terms for each license in a pool. If we are
+        # given licenses then they are used to calculate values for the LicensePool
+        # instead of directly using the values that are given to CirculationData.
         self.licenses = licenses
 
     @property

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -1366,9 +1366,9 @@ class CirculationData(MetaToModelUtility):
             if self.licenses is not None:
                 # If we have licenses set, use those to set our availability
                 old_licenses = list(pool.licenses or [])
-                new_licenses = []
-                for license in self.licenses:
-                    new_licenses.append(license.add_to_pool(_db, pool))
+                new_licenses = [
+                    license.add_to_pool(_db, pool) for license in self.licenses
+                ]
                 for license in old_licenses:
                     if license not in new_licenses:
                         self.log.warning(

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -11,6 +11,7 @@ import datetime
 import logging
 import re
 from collections import defaultdict
+from typing import Optional
 
 from dateutil.parser import parse
 from pymarc import MARCReader
@@ -48,6 +49,7 @@ from .model import (
     get_one_or_create,
 )
 from .model.configuration import ExternalIntegrationLink
+from .model.licensing import LicenseFunctions, LicenseStatus
 from .util import LanguageCodes
 from .util.datetime_helpers import strptime_utc, to_utc, utc_now
 from .util.http import RemoteIntegrationException
@@ -108,7 +110,7 @@ class ReplacementPolicy(object):
             rights=True,
             formats=True,
             analytics=Analytics(_db),
-            **args
+            **args,
         )
 
     @classmethod
@@ -125,7 +127,7 @@ class ReplacementPolicy(object):
             links=True,
             rights=False,
             formats=False,
-            **args
+            **args,
         )
 
     @classmethod
@@ -141,7 +143,7 @@ class ReplacementPolicy(object):
             links=False,
             rights=False,
             formats=False,
-            **args
+            **args,
         )
 
 
@@ -614,22 +616,37 @@ class FormatData(object):
             self.rights_uri = self.link.rights_uri
 
 
-class LicenseData(object):
+class LicenseData(LicenseFunctions):
     def __init__(
         self,
-        identifier,
-        checkout_url,
-        status_url,
-        expires=None,
-        remaining_checkouts=None,
-        concurrent_checkouts=None,
+        identifier: str,
+        checkout_url: str,
+        status_url: str,
+        status: LicenseStatus,
+        checkouts_available: int,
+        expires: Optional[datetime.datetime] = None,
+        checkouts_left: Optional[int] = None,
+        terms_concurrency: Optional[int] = None,
     ):
         self.identifier = identifier
         self.checkout_url = checkout_url
         self.status_url = status_url
+        self.status = status
         self.expires = expires
-        self.remaining_checkouts = remaining_checkouts
-        self.concurrent_checkouts = concurrent_checkouts
+        self.checkouts_left = checkouts_left
+        self.checkouts_available = checkouts_available
+        self.terms_concurrency = terms_concurrency
+
+    def add_to_pool(self, db: Session, pool: LicensePool):
+        license_obj, _ = get_one_or_create(
+            db,
+            License,
+            identifier=self.identifier,
+            license_pool=pool,
+        )
+        for key, value in vars(self).items():
+            setattr(license_obj, key, value)
+        return license_obj
 
 
 class TimestampData(object):
@@ -1047,7 +1064,7 @@ class CirculationData(MetaToModelUtility):
         self.links = links
 
         # Information about individual terms for each license in a pool.
-        self.licenses = licenses or []
+        self.licenses = licenses
 
     @property
     def links(self):
@@ -1055,7 +1072,7 @@ class CirculationData(MetaToModelUtility):
 
     @links.setter
     def links(self, arg_links):
-        """If got passed all links, undiscriminately, filter out to only those relevant to
+        """If got passed all links, indiscriminately, filter out to only those relevant to
         pools (the rights-related links).
         """
         # start by deleting any old links
@@ -1338,52 +1355,37 @@ class CirculationData(MetaToModelUtility):
         new_open_access = any(pool.open_access for pool in pools)
         open_access_status_changed = old_open_access != new_open_access
 
-        old_licenses = new_licenses = []
-        if pool:
-            old_licenses = list(pool.licenses or [])
-
-            for license in self.licenses:
-                license_obj, ignore = get_one_or_create(
-                    _db,
-                    License,
-                    identifier=license.identifier,
-                    license_pool_id=pool.id,
-                )
-                license_obj.checkout_url = license.checkout_url
-                license_obj.status_url = license.status_url
-                license_obj.expires = license.expires
-                license_obj.remaining_checkouts = license.remaining_checkouts
-                license_obj.concurrent_checkouts = license.concurrent_checkouts
-                new_licenses.append(license_obj)
-
-        for license in old_licenses:
-            if license not in new_licenses and license.loans:
-                # TODO: For ODL, I don't think this will happen, but
-                # it seems right not to delete the license if it does.
-                # We have the status URL we can use to check on the license,
-                # and if it is removed from the ODL feed when there are
-                # still loans we'll need it.
-                # But if we track individual licenses for other protocols,
-                # we may need to handle this differently.
-                self.log.warn(
-                    "License %i is no longer available but still has loans."
-                    % license.id
-                )
-
         # Finally, if we have data for a specific Collection's license
         # for this book, find its LicensePool and update it.
         changed_availability = False
         if pool and self._availability_needs_update(pool):
-            # Update availabily information. This may result in
+            # Update availability information. This may result in
             # the issuance of additional circulation events.
-            changed_availability = pool.update_availability(
-                new_licenses_owned=self.licenses_owned,
-                new_licenses_available=self.licenses_available,
-                new_licenses_reserved=self.licenses_reserved,
-                new_patrons_in_hold_queue=self.patrons_in_hold_queue,
-                analytics=analytics,
-                as_of=self.last_checked,
-            )
+            if self.licenses is not None:
+                # If we have licenses set, use those to set our availability
+                old_licenses = list(pool.licenses or [])
+                new_licenses = []
+                for license in self.licenses:
+                    new_licenses.append(license.add_to_pool(_db, pool))
+                for license in old_licenses:
+                    if license not in new_licenses:
+                        self.log.warning(
+                            f"License {license.identifier} has been removed from feed."
+                        )
+                changed_availability = pool.update_availability_from_licenses(
+                    analytics=analytics,
+                    as_of=self.last_checked,
+                )
+            else:
+                # Otherwise update the availability directly
+                changed_availability = pool.update_availability(
+                    new_licenses_owned=self.licenses_owned,
+                    new_licenses_available=self.licenses_available,
+                    new_licenses_reserved=self.licenses_reserved,
+                    new_patrons_in_hold_queue=self.patrons_in_hold_queue,
+                    analytics=analytics,
+                    as_of=self.last_checked,
+                )
 
         # If this is the first time we've seen this pool, or we never
         # made a Work for it, make one now.
@@ -1461,7 +1463,7 @@ class Metadata(MetaToModelUtility):
         data_source_last_updated=None,
         # Note: brought back to keep callers of bibliographic extraction process_one() methods simple.
         circulation=None,
-        **kwargs
+        **kwargs,
     ):
         # data_source is where the data comes from (e.g. overdrive, metadata wrangler, admin interface),
         # and not necessarily where the associated Identifier's LicencePool's lending licenses are coming from.
@@ -1567,7 +1569,7 @@ class Metadata(MetaToModelUtility):
             primary_identifier=primary_identifier,
             contributors=contributors,
             links=links,
-            **kwargs
+            **kwargs,
         )
 
     def normalize_contributors(self, metadata_client):

--- a/migration/20211109-update-licenses.sql
+++ b/migration/20211109-update-licenses.sql
@@ -1,6 +1,16 @@
-ALTER TABLE licenses RENAME COLUMN remaining_checkouts TO checkouts_left;
-ALTER TABLE licenses RENAME COLUMN concurrent_checkouts TO checkouts_available;
-CREATE TYPE licensestatus AS ENUM ('preorder', 'available', 'unavailable');
-ALTER TABLE licenses ADD COLUMN status licensestatus;
-UPDATE licenses SET status = 'available';
-ALTER TABLE licenses ADD COLUMN terms_concurrency INTEGER;
+DO $$
+ BEGIN
+  ALTER TABLE licenses RENAME COLUMN remaining_checkouts TO checkouts_left;
+  ALTER TABLE licenses RENAME COLUMN concurrent_checkouts TO checkouts_available;
+
+  BEGIN
+   CREATE TYPE licensestatus AS ENUM ('preorder', 'available', 'unavailable');
+  EXCEPTION
+   WHEN duplicate_object THEN RAISE NOTICE 'type "licensestatus" already exists, not creating it.';
+  END;
+
+  ALTER TABLE licenses ADD COLUMN status licensestatus;
+  UPDATE licenses SET status = 'available';
+  ALTER TABLE licenses ADD COLUMN terms_concurrency INTEGER;
+ END;
+$$;

--- a/migration/20211109-update-licenses.sql
+++ b/migration/20211109-update-licenses.sql
@@ -1,0 +1,6 @@
+ALTER TABLE licenses RENAME COLUMN remaining_checkouts TO checkouts_left;
+ALTER TABLE licenses RENAME COLUMN concurrent_checkouts TO checkouts_available;
+CREATE TYPE licensestatus AS ENUM ('preorder', 'available', 'unavailable');
+ALTER TABLE licenses ADD COLUMN status licensestatus;
+UPDATE licenses SET status = 'available';
+ALTER TABLE licenses ADD COLUMN terms_concurrency INTEGER;

--- a/model/licensing.py
+++ b/model/licensing.py
@@ -1,22 +1,18 @@
 # encoding: utf-8
 # PolicyException LicensePool, LicensePoolDeliveryMechanism, DeliveryMechanism,
 # RightsStatus
+import datetime
 import logging
+from enum import Enum as PythonEnum
+from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import (
-    Boolean,
-    Column,
-    DateTime,
-    ForeignKey,
-    Index,
-    Integer,
-    String,
-    Unicode,
-    UniqueConstraint,
-)
+from sqlalchemy import Boolean, Column, DateTime
+from sqlalchemy import Enum as AlchemyEnum
+from sqlalchemy import ForeignKey, Index, Integer, String, Unicode, UniqueConstraint
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
+from sqlalchemy.sql.expression import or_
 from sqlalchemy.sql.functions import func
 
 from ..util.datetime_helpers import utc_now
@@ -27,16 +23,85 @@ from .constants import DataSourceConstants, EditionConstants, LinkRelations, Med
 from .hasfulltablecache import HasFullTableCache
 from .patron import Hold, Loan, Patron
 
+if TYPE_CHECKING:
+    # Only import for type checking, since it creates an import cycle
+    from ..analytics import Analytics
+
 
 class PolicyException(Exception):
     pass
 
 
-class License(Base):
+class LicenseStatus(PythonEnum):
+    preorder = "preorder"
+    available = "available"
+    unavailable = "unavailable"
+
+    @classmethod
+    def get(cls, value: str):
+        return cls.__members__.get(value.lower(), cls.unavailable)
+
+
+class LicenseFunctions:
+    identifier: str
+    checkout_url: str
+    status_url: str
+    status: LicenseStatus
+    expires: Optional[datetime.datetime]
+    checkouts_left: Optional[int]
+    checkouts_available: int
+    terms_concurrency: Optional[int]
+
+    @property
+    def is_perpetual(self) -> bool:
+        return (self.expires is None) and (self.checkouts_left is None)
+
+    @property
+    def is_time_limited(self) -> bool:
+        return self.expires is not None
+
+    @property
+    def is_loan_limited(self) -> bool:
+        return self.checkouts_left is not None
+
+    @property
+    def is_expired(self) -> bool:
+        now = utc_now()
+        return (
+            (self.expires and self.expires <= now)
+            or (self.checkouts_left is not None and self.checkouts_left <= 0)
+            or (self.status != LicenseStatus.available)
+        )
+
+    @property
+    def owned(self) -> int:
+        if self.is_expired:
+            return 0
+        elif self.is_loan_limited:
+            return self.checkouts_left
+        else:
+            return self.terms_concurrency
+
+    @property
+    def available(self) -> int:
+        if self.is_expired:
+            return 0
+        else:
+            return self.checkouts_available
+
+
+class License(Base, LicenseFunctions):
     """A single license for a work from a given source.
 
-    TODO: This currently assumes all licenses for a pool have the same
-    delivery mechanisms, which may not always be true.
+    The fields on this license are based on the license information available in the
+    License Info Document used in the ODL specification here:
+    https://drafts.opds.io/odl-1.0.html#4-license-info-document
+
+    This model may have to be changed, if other vendors are tracking individual
+    licenses in the future.
+
+    TODO: This currently assumes all licenses for a pool have the same delivery
+          mechanisms, which may not always be true.
     """
 
     __tablename__ = "licenses"
@@ -45,10 +110,18 @@ class License(Base):
     identifier = Column(Unicode)
     checkout_url = Column(Unicode)
     status_url = Column(Unicode)
+    status = Column(AlchemyEnum(LicenseStatus))
 
     expires = Column(DateTime(timezone=True))
-    remaining_checkouts = Column(Integer)
-    concurrent_checkouts = Column(Integer)
+
+    # License info document checkouts.left field
+    checkouts_left = Column(Integer)
+
+    # License info document checkouts.available field
+    checkouts_available = Column(Integer)
+
+    # License info document terms.concurrency field
+    terms_concurrency = Column(Integer)
 
     # A License belongs to one LicensePool.
     license_pool_id = Column(Integer, ForeignKey("licensepools.id"), index=True)
@@ -63,24 +136,29 @@ class License(Base):
         loan.license = self
         return loan, is_new
 
-    @property
-    def is_perpetual(self):
-        return (self.expires is None) and (self.remaining_checkouts is None)
+    def checkout(self):
+        """
+        Update licenses internal accounting when a license is checked out.
+        """
+        if not self.is_expired:
+            if self.checkouts_left:
+                self.checkouts_left -= 1
+            if self.checkouts_available:
+                self.checkouts_available -= 1
+        else:
+            logging.warning(f"Checking out expired license # {self.identifier}.")
 
-    @property
-    def is_time_limited(self):
-        return self.expires is not None
-
-    @property
-    def is_loan_limited(self):
-        return self.remaining_checkouts is not None
-
-    @property
-    def is_expired(self):
-        now = utc_now()
-        return (self.expires and self.expires <= now) or (
-            self.remaining_checkouts is not None and self.remaining_checkouts <= 0
-        )
+    def checkin(self):
+        """
+        Update a licenses internal accounting when a license is checked in.
+        """
+        if not self.is_expired:
+            available = [self.checkouts_available + 1, self.terms_concurrency]
+            if self.is_loan_limited:
+                available.append(self.checkouts_left)
+            self.checkouts_available = min(available)
+        else:
+            logging.warning(f"Checking in expired license # {self.identifier}.")
 
 
 class LicensePool(Base):
@@ -567,6 +645,57 @@ class LicensePool(Base):
         age = now - self.last_checked
         return age > maximum_stale_time
 
+    def update_availability_from_licenses(
+        self,
+        analytics: "Analytics" = None,
+        as_of: datetime.datetime = None,
+    ):
+        """
+        Update the LicensePool with new availability information, based on the
+        licenses and holds that are associated with it.
+
+        Log the implied changes with the analytics provider.
+        """
+        _db = Session.object_session(self)
+
+        licenses_owned = sum([l.owned for l in self.licenses])
+        licenses_available = sum([l.available for l in self.licenses])
+
+        holds = self.get_active_holds()
+
+        patrons_in_hold_queue = len(holds)
+        if len(holds) > licenses_available:
+            licenses_reserved = licenses_available
+            licenses_available = 0
+        else:
+            licenses_reserved = len(holds)
+            licenses_available -= licenses_reserved
+
+        return self.update_availability(
+            licenses_owned,
+            licenses_available,
+            licenses_reserved,
+            patrons_in_hold_queue,
+            analytics=analytics,
+            as_of=as_of,
+        )
+
+    def get_active_holds(self):
+        _db = Session.object_session(self)
+        return (
+            _db.query(Hold)
+            .filter(Hold.license_pool_id == self.id)
+            .filter(
+                or_(
+                    Hold.end == None,
+                    Hold.end > utc_now(),
+                    Hold.position > 0,
+                )
+            )
+            .order_by(Hold.start)
+            .all()
+        )
+
     def update_availability(
         self,
         new_licenses_owned,
@@ -580,7 +709,6 @@ class LicensePool(Base):
         Log the implied changes with the analytics provider.
         """
         changes_made = False
-        _db = Session.object_session(self)
         if not as_of:
             as_of = utc_now()
         elif as_of == CirculationEvent.NO_DATE:
@@ -980,7 +1108,7 @@ class LicensePool(Base):
             active_loan_count = len(
                 [l for l in license.loans if not l.end or l.end > now]
             )
-            if active_loan_count >= license.concurrent_checkouts:
+            if active_loan_count >= license.checkouts_available:
                 continue
 
             if (
@@ -995,7 +1123,7 @@ class LicensePool(Base):
                 or (
                     license.is_loan_limited
                     and best.is_loan_limited
-                    and license.remaining_checkouts > best.remaining_checkouts
+                    and license.checkouts_left > best.checkouts_left
                 )
             ):
                 best = license

--- a/scripts.py
+++ b/scripts.py
@@ -1763,13 +1763,6 @@ class CollectionInputScript(Script):
             action="append",
             default=[],
         )
-        parser.add_argument(
-            "--collection-type",
-            help="Collection type. Valid values are: OPEN_ACCESS (default), PROTECTED_ACCESS.",
-            type=CollectionType,
-            choices=list(CollectionType),
-            default=CollectionType.OPEN_ACCESS,
-        )
         return parser
 
 
@@ -1879,6 +1872,18 @@ class MirrorResourcesScript(CollectionInputScript):
 
     # This object contains the actual logic of mirroring.
     MIRROR_UTILITY = MetaToModelUtility()
+
+    @classmethod
+    def arg_parser(cls):
+        parser = super().arg_parser()
+        parser.add_argument(
+            "--collection-type",
+            help="Collection type. Valid values are: OPEN_ACCESS (default), PROTECTED_ACCESS.",
+            type=CollectionType,
+            choices=list(CollectionType),
+            default=CollectionType.OPEN_ACCESS,
+        )
+        return parser
 
     def do_run(self, cmd_args=None):
         parsed = self.parse_command_line(self._db, cmd_args=cmd_args)

--- a/testing.py
+++ b/testing.py
@@ -69,6 +69,7 @@ from .model import (
 )
 from .model.configuration import ExternalIntegrationLink
 from .model.constants import MediaTypes
+from .model.licensing import LicenseStatus
 from .util.datetime_helpers import datetime_utc, utc_now
 
 
@@ -619,8 +620,10 @@ class DatabaseTest(object):
         checkout_url=None,
         status_url=None,
         expires=None,
-        remaining_checkouts=None,
-        concurrent_checkouts=None,
+        checkouts_left=None,
+        checkouts_available=None,
+        status=LicenseStatus.available,
+        terms_concurrency=None,
     ):
         identifier = identifier or self._str
         checkout_url = checkout_url or self._str
@@ -633,8 +636,10 @@ class DatabaseTest(object):
             checkout_url=checkout_url,
             status_url=status_url,
             expires=expires,
-            remaining_checkouts=remaining_checkouts,
-            concurrent_checkouts=concurrent_checkouts,
+            checkouts_left=checkouts_left,
+            checkouts_available=checkouts_available,
+            status=status,
+            terms_concurrency=terms_concurrency,
         )
         return license
 

--- a/tests/models/test_licensing.py
+++ b/tests/models/test_licensing.py
@@ -305,7 +305,15 @@ class TestLicense(DatabaseTest):
         assert False == is_new
 
     @pytest.mark.parametrize(
-        "license_type,is_perpetual,is_time_limited,is_loan_limited,is_expired,owned,available",
+        (
+            "license_type",
+            "is_perpetual",
+            "is_time_limited",
+            "is_loan_limited",
+            "is_inactive",
+            "total_remaining_loans",
+            "currently_available_loans",
+        ),
         [
             ("perpetual", True, False, False, False, 2, 1),
             ("time_limited", False, True, False, False, 1, 1),
@@ -322,17 +330,17 @@ class TestLicense(DatabaseTest):
         is_perpetual,
         is_time_limited,
         is_loan_limited,
-        is_expired,
-        owned,
-        available,
+        is_inactive,
+        total_remaining_loans,
+        currently_available_loans,
     ):
         license = getattr(self, license_type)
         assert is_perpetual == license.is_perpetual
         assert is_time_limited == license.is_time_limited
         assert is_loan_limited == license.is_loan_limited
-        assert is_expired == license.is_expired
-        assert owned == license.owned
-        assert available == license.available
+        assert is_inactive == license.is_inactive
+        assert total_remaining_loans == license.total_remaining_loans
+        assert currently_available_loans == license.currently_available_loans
 
     @pytest.mark.parametrize(
         "license_type,left,available",

--- a/tests/models/test_licensing.py
+++ b/tests/models/test_licensing.py
@@ -23,6 +23,7 @@ from ...model.licensing import (
     License,
     LicensePool,
     LicensePoolDeliveryMechanism,
+    LicenseStatus,
     Loan,
     RightsStatus,
 )
@@ -182,7 +183,6 @@ class TestDeliveryMechanism(DatabaseTest):
         assert False == epub_no_drm.compatible_with(pdf_adobe, True)
 
     def test_uniqueness_constraint(self):
-
         dm = DeliveryMechanism
 
         # You can't create two DeliveryMechanisms with the same values
@@ -236,36 +236,54 @@ class TestLicense(DatabaseTest):
         yesterday = now - datetime.timedelta(days=1)
 
         self.perpetual = self._license(
-            self.pool, expires=None, remaining_checkouts=None, concurrent_checkouts=1
+            self.pool,
+            expires=None,
+            checkouts_left=None,
+            checkouts_available=1,
+            terms_concurrency=2,
         )
 
         self.time_limited = self._license(
             self.pool,
             expires=next_year,
-            remaining_checkouts=None,
-            concurrent_checkouts=1,
+            checkouts_left=None,
+            checkouts_available=1,
+            terms_concurrency=1,
         )
 
         self.loan_limited = self._license(
-            self.pool, expires=None, remaining_checkouts=4, concurrent_checkouts=2
+            self.pool,
+            expires=None,
+            checkouts_left=4,
+            checkouts_available=2,
+            terms_concurrency=3,
         )
 
         self.time_and_loan_limited = self._license(
             self.pool,
             expires=next_year + datetime.timedelta(days=1),
-            remaining_checkouts=52,
-            concurrent_checkouts=1,
+            checkouts_left=52,
+            checkouts_available=1,
+            terms_concurrency=1,
         )
 
         self.expired_time_limited = self._license(
             self.pool,
             expires=yesterday,
-            remaining_checkouts=None,
-            concurrent_checkouts=1,
+            checkouts_left=None,
+            checkouts_available=1,
         )
 
         self.expired_loan_limited = self._license(
-            self.pool, expires=None, remaining_checkouts=0, concurrent_checkouts=1
+            self.pool, expires=None, checkouts_left=0, checkouts_available=1
+        )
+
+        self.unavailable = self._license(
+            self.pool,
+            expires=None,
+            checkouts_left=None,
+            checkouts_available=20,
+            status=LicenseStatus.unavailable,
         )
 
     def test_loan_to(self):
@@ -286,47 +304,120 @@ class TestLicense(DatabaseTest):
         assert pool == loan2.license_pool
         assert False == is_new
 
-    def test_license_types(self):
-        assert True == self.perpetual.is_perpetual
-        assert False == self.perpetual.is_time_limited
-        assert False == self.perpetual.is_loan_limited
-        assert False == self.perpetual.is_expired
+    @pytest.mark.parametrize(
+        "license_type,is_perpetual,is_time_limited,is_loan_limited,is_expired,owned,available",
+        [
+            ("perpetual", True, False, False, False, 2, 1),
+            ("time_limited", False, True, False, False, 1, 1),
+            ("loan_limited", False, False, True, False, 4, 2),
+            ("time_and_loan_limited", False, True, True, False, 52, 1),
+            ("expired_time_limited", False, True, False, True, 0, 0),
+            ("expired_loan_limited", False, False, True, True, 0, 0),
+            ("unavailable", True, False, False, True, 0, 0),
+        ],
+    )
+    def test_license_types(
+        self,
+        license_type,
+        is_perpetual,
+        is_time_limited,
+        is_loan_limited,
+        is_expired,
+        owned,
+        available,
+    ):
+        license = getattr(self, license_type)
+        assert is_perpetual == license.is_perpetual
+        assert is_time_limited == license.is_time_limited
+        assert is_loan_limited == license.is_loan_limited
+        assert is_expired == license.is_expired
+        assert owned == license.owned
+        assert available == license.available
 
-        assert False == self.time_limited.is_perpetual
-        assert True == self.time_limited.is_time_limited
-        assert False == self.time_limited.is_loan_limited
-        assert False == self.time_limited.is_expired
+    @pytest.mark.parametrize(
+        "license_type,left,available",
+        [
+            ("perpetual", None, 0),
+            ("time_limited", None, 0),
+            ("loan_limited", 3, 1),
+            ("time_and_loan_limited", 51, 0),
+            ("expired_time_limited", None, 1),
+            ("expired_loan_limited", 0, 1),
+            ("unavailable", None, 20),
+        ],
+    )
+    def test_license_checkout(self, license_type, left, available):
+        license = getattr(self, license_type)
+        license.checkout()
+        assert left == license.checkouts_left
+        assert available == license.checkouts_available
 
-        assert False == self.loan_limited.is_perpetual
-        assert False == self.loan_limited.is_time_limited
-        assert True == self.loan_limited.is_loan_limited
-        assert False == self.loan_limited.is_expired
-
-        assert False == self.time_and_loan_limited.is_perpetual
-        assert True == self.time_and_loan_limited.is_time_limited
-        assert True == self.time_and_loan_limited.is_loan_limited
-        assert False == self.time_and_loan_limited.is_expired
-
-        assert False == self.expired_time_limited.is_perpetual
-        assert True == self.expired_time_limited.is_time_limited
-        assert False == self.expired_time_limited.is_loan_limited
-        assert True == self.expired_time_limited.is_expired
-
-        assert False == self.expired_loan_limited.is_perpetual
-        assert False == self.expired_loan_limited.is_time_limited
-        assert True == self.expired_loan_limited.is_loan_limited
-        assert True == self.expired_loan_limited.is_expired
+    @pytest.mark.parametrize(
+        "license_params,left,available",
+        [
+            ({"checkouts_available": 1, "terms_concurrency": 2}, None, 2),
+            ({"checkouts_available": 1, "terms_concurrency": 1}, None, 1),
+            (
+                {
+                    "expires": utc_now() + datetime.timedelta(days=7),
+                    "checkouts_available": 0,
+                    "terms_concurrency": 1,
+                },
+                None,
+                1,
+            ),
+            (
+                {"checkouts_available": 0, "terms_concurrency": 1, "checkouts_left": 4},
+                4,
+                1,
+            ),
+            (
+                {"checkouts_available": 2, "terms_concurrency": 5, "checkouts_left": 2},
+                2,
+                2,
+            ),
+            (
+                {"checkouts_available": 0, "terms_concurrency": 1, "checkouts_left": 0},
+                0,
+                0,
+            ),
+            (
+                {
+                    "expires": utc_now() + datetime.timedelta(days=7),
+                    "checkouts_available": 5,
+                    "terms_concurrency": 6,
+                    "checkouts_left": 40,
+                },
+                40,
+                6,
+            ),
+            (
+                {
+                    "expires": utc_now() - datetime.timedelta(days=7),
+                    "checkouts_available": 4,
+                    "terms_concurrency": 5,
+                },
+                None,
+                4,
+            ),
+        ],
+    )
+    def test_license_checkin(self, license_params, left, available):
+        l = self._license(self.pool, **license_params)
+        l.checkin()
+        assert left == l.checkouts_left
+        assert available == l.checkouts_available
 
     def test_best_available_license(self):
         next_week = utc_now() + datetime.timedelta(days=7)
         time_limited_2 = self._license(
             self.pool,
             expires=next_week,
-            remaining_checkouts=None,
-            concurrent_checkouts=1,
+            checkouts_left=None,
+            checkouts_available=1,
         )
         loan_limited_2 = self._license(
-            self.pool, expires=None, remaining_checkouts=2, concurrent_checkouts=1
+            self.pool, expires=None, checkouts_left=2, checkouts_available=1
         )
 
         # First, we use the time-limited license that's expiring first.
@@ -593,7 +684,6 @@ class TestLicensePool(DatabaseTest):
         assert set([oa1, oa2]) == set(pool.open_access_links)
 
     def test_better_open_access_pool_than(self):
-
         gutenberg_1 = self._licensepool(
             None,
             open_access=True,
@@ -863,7 +953,6 @@ class TestLicensePool(DatabaseTest):
         assert set([jane]) == presentation.contributors
 
     def test_circulation_changelog(self):
-
         edition, pool = self._edition(with_license_pool=True)
         pool.licenses_owned = 10
         pool.licenses_available = 9

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -321,7 +321,7 @@ class TestCirculationData(DatabaseTest):
             licenses_owned=999,
             licenses_available=999,
             licenses_reserved=999,
-            patrons_in_hold_queue=999
+            patrons_in_hold_queue=999,
         )
 
         circulation_data.apply(self._db, pool.collection)
@@ -344,7 +344,7 @@ class TestCirculationData(DatabaseTest):
             licenses_owned=999,
             licenses_available=999,
             licenses_reserved=999,
-            patrons_in_hold_queue=999
+            patrons_in_hold_queue=999,
         )
 
         circulation_data.apply(self._db, pool.collection)

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -243,6 +243,7 @@ class TestCirculationData(DatabaseTest):
             expires=(utc_now() + datetime.timedelta(days=7)),
             checkouts_left=None,
             checkouts_available=1,
+            terms_concurrency=1,
             status=LicenseStatus.available,
         )
 


### PR DESCRIPTION
Make sure we are correctly tracking licenses for OPDS+ODL collections.

This PR makes a few related changes.
  - Update the columns on `Licenses`
    -  Reflect the terms used in [OPDS2+ODL](https://drafts.opds.io/odl-1.0.html), rather then OPDS+ODL.
    - Add a new `status` column to so we can track the status of each license.
    - Add a new `terms_concurrency` column to track the concurrency allowed for the license.
  - Update `CirculationData` so that if it is given licenses they are used to calculate the `licenses_owned`, `licenses_available`, `licenses_reserved` and `patrons_in_hold_queue` values for a pool. If no licenses are given, then the values from `CirculationData` are used directly.