### PR TITLE
Fix the sorting order in Work.missing_coverage_from

### DIFF
--- a/model/work.py
+++ b/model/work.py
@@ -331,7 +331,11 @@ class Work(Base):
             Work.id == WorkCoverageRecord.work_id,
             WorkCoverageRecord.operation == operation,
         )
-        q = _db.query(Work).outerjoin(WorkCoverageRecord, clause).order_by(Work.id)
+        q = (
+            _db.query(Work)
+            .outerjoin(WorkCoverageRecord, clause)
+            .order_by(Work.id, WorkCoverageRecord.id)
+        )
 
         missing = WorkCoverageRecord.not_covered(
             count_as_covered, count_as_missing_before


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR updates the sorting order in Work.missing_coverage_from: it sorts resulting records by both `Work.id` and `WorkCoverageRecord.id`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
