### PR TITLE
Cleanup some unused imports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Run Black
         run: tox -e black
 
+      - name: Run autoflake
+        run: tox -e autoflake
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/analytics.py
+++ b/analytics.py
@@ -1,6 +1,4 @@
-import contextlib
 import importlib
-import os
 from collections import defaultdict
 
 from sqlalchemy.orm.session import Session

--- a/bin/initialize_database
+++ b/bin/initialize_database
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Run any new migrations from the database"""
-import startup
+import startup  # noqa
+
 from core.scripts import DatabaseMigrationInitializationScript
 
 DatabaseMigrationInitializationScript().run()

--- a/bin/migrate_database
+++ b/bin/migrate_database
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Run any new migrations from the database"""
-import startup
+import startup  # noqa
+
 from core.scripts import DatabaseMigrationScript
 
 DatabaseMigrationScript().run()

--- a/bin/opds_entry_coverage
+++ b/bin/opds_entry_coverage
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Make sure all presentation-ready works have up-to-date OPDS entries."""
-import startup
+import startup  # noqa
+
 from core.coverage import OPDSEntryWorkCoverageProvider
 from core.scripts import RunWorkCoverageProviderScript
 

--- a/bin/repair/check_contributor_names
+++ b/bin/repair/check_contributor_names
@@ -12,7 +12,8 @@ python bin/repair/check_contributor_names --identifier-type 'RBDigital ID' 97814
 which generates a report file that lists the contributors affected, and whether their names
 were fixed or complained about.
 """
-import startup
+import startup  # noqa
+
 from core.scripts import CheckContributorNamesInDB
 
 CheckContributorNamesInDB().run()

--- a/classifier/__init__.py
+++ b/classifier/__init__.py
@@ -12,16 +12,12 @@
 # SQL to find commonly used classifications not assigned to a genre
 # select count(identifiers.id) as c, subjects.type, substr(subjects.identifier, 0, 20) as i, substr(subjects.name, 0, 20) as n from workidentifiers join classifications on workidentifiers.id=classifications.work_identifier_id join subjects on classifications.subject_id=subjects.id where subjects.genre_id is null and subjects.fiction is null group by subjects.type, i, n order by c desc;
 
-import json
 import logging
 import os
-import pkgutil
 import re
-from collections import Counter, defaultdict
-from urllib.parse import urlparse
+from collections import Counter
 
 from sqlalchemy.orm.session import Session
-from sqlalchemy.sql.expression import and_
 
 base_dir = os.path.split(__file__)[0]
 resource_dir = os.path.join(base_dir, "..", "resources")
@@ -1392,7 +1388,6 @@ class WorkClassifier(object):
         research_weight = w.get(Classifier.AUDIENCE_RESEARCH, 0)
 
         total_adult_weight = adult_weight + adults_only_weight
-        total_weight = sum(w.values())
 
         audience = default_audience
 
@@ -1623,18 +1618,18 @@ Classifier.classifiers[Classifier.FREEFORM_AUDIENCE] = FreeformAudienceClassifie
 Classifier.classifiers[Classifier.AXIS_360_AUDIENCE] = AgeOrGradeClassifier
 
 # Finally, import classifiers described in submodules.
-from .age import AgeClassifier, GradeLevelClassifier, InterestLevelClassifier
-from .bic import BICClassifier
-from .bisac import BISACClassifier
-from .ddc import DeweyDecimalClassifier
-from .gutenberg import GutenbergBookshelfClassifier
-from .keyword import (
+from .age import AgeClassifier, GradeLevelClassifier, InterestLevelClassifier  # noqa
+from .bic import BICClassifier  # noqa
+from .bisac import BISACClassifier  # noqa
+from .ddc import DeweyDecimalClassifier  # noqa
+from .gutenberg import GutenbergBookshelfClassifier  # noqa
+from .keyword import (  # noqa
     Eg,
     FASTClassifier,
     KeywordBasedClassifier,
     LCSHClassifier,
     TAGClassifier,
 )
-from .lcc import LCCClassifier
-from .overdrive import OverdriveClassifier
-from .simplified import SimplifiedFictionClassifier, SimplifiedGenreClassifier
+from .lcc import LCCClassifier  # noqa
+from .overdrive import OverdriveClassifier  # noqa
+from .simplified import SimplifiedFictionClassifier, SimplifiedGenreClassifier  # noqa

--- a/classifier/bic.py
+++ b/classifier/bic.py
@@ -1,4 +1,4 @@
-from . import *
+from . import *  # noqa
 
 
 class BICClassifier(Classifier):

--- a/classifier/bisac.py
+++ b/classifier/bisac.py
@@ -2,9 +2,8 @@
 import csv
 import os
 import re
-import string
 
-from . import *
+from . import *  # noqa
 from .keyword import KeywordBasedClassifier
 
 

--- a/classifier/ddc.py
+++ b/classifier/ddc.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-from . import *
+from . import *  # noqa
 
 base_dir = os.path.split(__file__)[0]
 resource_dir = os.path.join(base_dir, "..", "resources")

--- a/classifier/gutenberg.py
+++ b/classifier/gutenberg.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-from . import *
+from . import *  # noqa
 
 
 class GutenbergBookshelfClassifier(Classifier):

--- a/classifier/keyword.py
+++ b/classifier/keyword.py
@@ -1,4 +1,4 @@
-from . import *
+from . import *  # noqa
 
 
 def match_kw(*l):
@@ -1210,7 +1210,6 @@ class KeywordBasedClassifier(AgeOrGradeClassifier):
         cls, identifier, name, fiction=None, audience=None, exclude_examples=False
     ):
         matches = Counter()
-        match_against = [name]
         for l in [cls.LEVEL_3_KEYWORDS, cls.LEVEL_2_KEYWORDS, cls.CATCHALL_KEYWORDS]:
             for genre, keywords in list(l.items()):
                 if genre and fiction is not None and genre.is_fiction != fiction:

--- a/classifier/lcc.py
+++ b/classifier/lcc.py
@@ -1,4 +1,6 @@
-from . import *
+import json
+
+from . import *  # noqa
 
 
 class LCCClassifier(Classifier):

--- a/classifier/overdrive.py
+++ b/classifier/overdrive.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-from . import *
+from . import *  # noqa
 
 
 class OverdriveClassifier(Classifier):

--- a/classifier/simplified.py
+++ b/classifier/simplified.py
@@ -1,6 +1,6 @@
 from urllib.parse import unquote
 
-from . import *
+from . import *  # noqa
 
 
 class SimplifiedGenreClassifier(Classifier):

--- a/config.py
+++ b/config.py
@@ -5,10 +5,8 @@ import logging
 import os
 
 from flask_babel import lazy_gettext as _
-from sqlalchemy import create_engine
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import ArgumentError
-from sqlalchemy.orm.session import Session
 
 from .entrypoint import EntryPoint
 from .facets import FacetConstants
@@ -29,8 +27,6 @@ class CannotLoadConfiguration(IntegrationException):
     configuration, with no need to actually talk to the foreign
     server.
     """
-
-    pass
 
 
 @contextlib.contextmanager
@@ -474,10 +470,8 @@ class Configuration(ConfigurationConstants):
         # tests/__init__.py.
         test = os.environ.get("TESTING", False)
         if test:
-            config_key = cls.DATABASE_TEST_URL
             environment_variable = cls.DATABASE_TEST_ENVIRONMENT_VARIABLE
         else:
-            config_key = cls.DATABASE_PRODUCTION_URL
             environment_variable = cls.DATABASE_PRODUCTION_ENVIRONMENT_VARIABLE
 
         url = os.environ.get(environment_variable)
@@ -487,10 +481,9 @@ class Configuration(ConfigurationConstants):
                 % environment_variable
             )
 
-        url_obj = None
         try:
             url_obj = make_url(url)
-        except ArgumentError as e:
+        except ArgumentError:
             # Improve the error message by giving a guide as to what's
             # likely to work.
             raise ArgumentError(

--- a/coverage.py
+++ b/coverage.py
@@ -13,7 +13,6 @@ from .model import (
     CoverageRecord,
     DataSource,
     Edition,
-    ExternalIntegration,
     Identifier,
     LicensePool,
     PresentationCalculationPolicy,
@@ -21,7 +20,6 @@ from .model import (
     Work,
     WorkCoverageRecord,
     get_one,
-    get_one_or_create,
 )
 from .util.datetime_helpers import utc_now
 from .util.worker_pools import DatabaseJob
@@ -228,7 +226,6 @@ class BaseCoverageProvider(object):
             BaseCoverageRecord.DEFAULT_COUNT_AS_COVERED,
         ]
         start_time = utc_now()
-        timestamp = self.timestamp
 
         # We'll use this TimestampData object to track our progress
         # as we grant coverage to items.
@@ -396,7 +393,6 @@ class BaseCoverageProvider(object):
         # a list ensures that all subsequent code will run on the same items.
         batch = list(batch)
 
-        offset_increment = 0
         results = self.process_batch(batch)
         successes = 0
         transient_failures = 0
@@ -489,7 +485,6 @@ class BaseCoverageProvider(object):
         """Do something special to mark the successful coverage of the
         given item.
         """
-        pass
 
     def should_update(self, coverage_record):
         """Should we do the work to update the given coverage record?"""

--- a/external_list.py
+++ b/external_list.py
@@ -1,10 +1,7 @@
 # encoding: utf-8
-import csv
 import logging
-import os
 from collections import defaultdict
 
-from dateutil.parser import parse
 from sqlalchemy import or_
 from sqlalchemy.orm.session import Session
 
@@ -19,11 +16,9 @@ from .model import (
     Identifier,
     Subject,
     Work,
-    get_one,
     get_one_or_create,
 )
 from .opds_import import SimplifiedOPDSLookup
-from .util import LanguageCodes
 from .util.datetime_helpers import utc_now
 
 
@@ -84,7 +79,7 @@ class CustomListFromCSV(CSVMetadataImporter):
         # Turn the rows of the CSV file into a sequence of Metadata
         # objects, then turn each Metadata into a CustomListEntry object.
         for metadata in self.to_metadata(dictreader):
-            entry = self.metadata_to_list_entry(custom_list, data_source, now, metadata)
+            self.metadata_to_list_entry(custom_list, data_source, now, metadata)
 
     def metadata_to_list_entry(self, custom_list, data_source, now, metadata):
         """Convert a Metadata object to a CustomListEntry."""
@@ -234,7 +229,7 @@ class TitleFromExternalList(object):
         # ID if possible.
         try:
             edition, is_new = self.metadata.edition(_db)
-        except ValueError as e:
+        except ValueError:
             self.log.info("Ignoring %s, no corresponding edition.", self.metadata.title)
             return None
         if overwrite_old_data:

--- a/log.py
+++ b/log.py
@@ -1,8 +1,6 @@
 import json
 import logging
-import os
 import socket
-from io import StringIO
 
 from boto3.session import Session as AwsSession
 from flask_babel import lazy_gettext as _
@@ -227,7 +225,7 @@ class Loggly(Logger):
             )
         try:
             url = cls._interpolate_loggly_url(url, token)
-        except (TypeError, KeyError) as e:
+        except (TypeError, KeyError):
             raise CannotLoadConfiguration(
                 "Cannot interpolate token %s into loggly URL %s"
                 % (

--- a/marc.py
+++ b/marc.py
@@ -2,17 +2,15 @@ import re
 from io import BytesIO
 
 from flask_babel import lazy_gettext as _
-from pymarc import Field, MARCWriter, Record
+from pymarc import Field, Record
 
 from .classifier import Classifier
-from .config import CannotLoadConfiguration, Configuration
+from .config import CannotLoadConfiguration
 from .external_search import ExternalSearchIndex, SortKeyPagination
 from .lane import BaseFacets, Lane
 from .mirror import MirrorUploader
 from .model import (
     CachedMARCFile,
-    Collection,
-    ConfigurationSetting,
     DeliveryMechanism,
     Edition,
     ExternalIntegration,
@@ -20,10 +18,8 @@ from .model import (
     Representation,
     Session,
     Work,
-    get_one,
     get_one_or_create,
 )
-from .s3 import S3Uploader
 from .util import LanguageCodes
 from .util.datetime_helpers import utc_now
 
@@ -212,7 +208,6 @@ class Annotator(object):
 
         TODO: Use canonical names from LoC.
         """
-        contibutor_fields = []
 
         # If there's one author, use the 100 field.
         if edition.sort_author and len(edition.contributions) == 1:
@@ -428,7 +423,6 @@ class Annotator(object):
 
     @classmethod
     def add_formats(cls, record, pool):
-        formats = []
         for lpdm in pool.delivery_mechanisms:
             format = None
             dm = lpdm.delivery_mechanism
@@ -657,8 +651,6 @@ class MARCExporter(object):
 
         edition = pool.presentation_edition
         identifier = pool.identifier
-
-        _db = Session.object_session(work)
 
         record = None
         existing_record = getattr(work, annotator.marc_cache_field)

--- a/metadata_layer.py
+++ b/metadata_layer.py
@@ -7,15 +7,12 @@ model. Doing a third-party integration should be as simple as putting
 the information into this format.
 """
 import csv
-import datetime
 import logging
 import re
 from collections import defaultdict
 
 from dateutil.parser import parse
 from pymarc import MARCReader
-from sqlalchemy.orm import aliased
-from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import and_, or_
 
@@ -30,7 +27,6 @@ from .model import (
     DataSource,
     DeliveryMechanism,
     Edition,
-    Equivalency,
     Hyperlink,
     Identifier,
     License,
@@ -43,7 +39,6 @@ from .model import (
     RightsStatus,
     Subject,
     Timestamp,
-    Work,
     get_one,
     get_one_or_create,
 )
@@ -1720,7 +1715,6 @@ class Metadata(MetaToModelUtility):
             ):
                 continue
             contributor.find_sort_name(_db, self.identifiers, metadata_client)
-            confidence = 0
 
             base = (
                 _db.query(Edition)
@@ -2473,7 +2467,6 @@ class CSVMetadataImporter(object):
 
     def _date_field(self, row, field_name):
         """Attempt to parse a field as a date."""
-        date = None
         value = self._field(row, field_name)
         if value:
             try:

--- a/mirror.py
+++ b/mirror.py
@@ -72,7 +72,7 @@ class MirrorUploader(metaclass=ABCMeta):
             integration = ExternalIntegration.for_collection_and_purpose(
                 _db, collection, purpose
             )
-        except CannotLoadConfiguration as e:
+        except CannotLoadConfiguration:
             return None
         return cls.implementation(integration)
 

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -6,10 +6,10 @@ import warnings
 
 from psycopg2.extensions import adapt as sqlescape
 from psycopg2.extras import NumericRange
-from sqlalchemy import Column, ForeignKey, Integer, Table, create_engine, text
+from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError, SAWarning
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship, sessionmaker
+from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.sql import compiler, select
 from sqlalchemy.sql.expression import literal_column, table
@@ -17,14 +17,6 @@ from sqlalchemy.sql.expression import literal_column, table
 Base = declarative_base()
 
 from .. import classifier
-from ..util.datetime_helpers import utc_now
-from .constants import (
-    DataSourceConstants,
-    EditionConstants,
-    IdentifierConstants,
-    LinkRelations,
-    MediaTypes,
-)
 
 
 def flush(db):
@@ -478,33 +470,49 @@ def production_session(initialize_data=True):
     return _db
 
 
-from .admin import Admin, AdminRole
-from .cachedfeed import CachedFeed, CachedMARCFile, WillNotGenerateExpensiveFeed
-from .circulationevent import CirculationEvent
-from .classification import Classification, Genre, Subject
-from .collection import (
+from .admin import Admin, AdminRole  # noqa
+from .cachedfeed import CachedFeed, CachedMARCFile, WillNotGenerateExpensiveFeed  # noqa
+from .circulationevent import CirculationEvent  # noqa
+from .classification import Classification, Genre, Subject  # noqa
+from .collection import (  # noqa
     Collection,
     CollectionIdentifier,
     CollectionMissing,
     collections_identifiers,
 )
-from .complaint import Complaint
-from .configuration import (
+from .complaint import Complaint  # noqa
+from .configuration import (  # noqa
     ConfigurationSetting,
     ExternalIntegration,
     ExternalIntegrationLink,
 )
-from .contributor import Contribution, Contributor
-from .coverage import BaseCoverageRecord, CoverageRecord, Timestamp, WorkCoverageRecord
-from .credential import Credential, DelegatedPatronIdentifier, DRMDeviceIdentifier
-from .customlist import CustomList, CustomListEntry
-from .datasource import DataSource
-from .edition import Edition
-from .hasfulltablecache import HasFullTableCache
-from .identifier import Equivalency, Identifier
-from .integrationclient import IntegrationClient
-from .library import Library
-from .licensing import (
+from .constants import (  # noqa
+    DataSourceConstants,
+    EditionConstants,
+    IdentifierConstants,
+    LinkRelations,
+    MediaTypes,
+)
+from .contributor import Contribution, Contributor  # noqa
+from .coverage import (  # noqa
+    BaseCoverageRecord,
+    CoverageRecord,
+    Timestamp,
+    WorkCoverageRecord,
+)
+from .credential import (  # noqa
+    Credential,
+    DelegatedPatronIdentifier,
+    DRMDeviceIdentifier,
+)
+from .customlist import CustomList, CustomListEntry  # noqa
+from .datasource import DataSource  # noqa
+from .edition import Edition  # noqa
+from .hasfulltablecache import HasFullTableCache  # noqa
+from .identifier import Equivalency, Identifier  # noqa
+from .integrationclient import IntegrationClient  # noqa
+from .library import Library  # noqa
+from .licensing import (  # noqa
     DeliveryMechanism,
     License,
     LicensePool,
@@ -512,9 +520,9 @@ from .licensing import (
     PolicyException,
     RightsStatus,
 )
-from .listeners import *
-from .measurement import Measurement
-from .patron import (
+from .listeners import *  # noqa
+from .measurement import Measurement  # noqa
+from .patron import (  # noqa
     Annotation,
     Hold,
     Loan,
@@ -522,5 +530,10 @@ from .patron import (
     Patron,
     PatronProfileStorage,
 )
-from .resource import Hyperlink, Representation, Resource, ResourceTransformation
-from .work import Work, WorkGenre
+from .resource import (  # noqa
+    Hyperlink,
+    Representation,
+    Resource,
+    ResourceTransformation,
+)
+from .work import Work, WorkGenre  # noqa

--- a/model/cachedfeed.py
+++ b/model/cachedfeed.py
@@ -395,8 +395,6 @@ class WillNotGenerateExpensiveFeed(Exception):
     expensive to generate.
     """
 
-    pass
-
 
 class CachedMARCFile(Base):
     """A record that a MARC file has been created and cached for a particular lane."""

--- a/model/classification.py
+++ b/model/classification.py
@@ -196,7 +196,6 @@ class Subject(Base):
     @classmethod
     def lookup(cls, _db, type, identifier, name, autocreate=True):
         """Turn a subject type and identifier into a Subject."""
-        classifier = Classifier.lookup(type)
         if not type:
             raise ValueError("Cannot look up Subject with no type.")
         if not identifier and not name:

--- a/model/collection.py
+++ b/model/collection.py
@@ -170,7 +170,7 @@ class Collection(Base, HasFullTableCache):
         try:
             collection = qu.one()
             is_new = False
-        except NoResultFound as e:
+        except NoResultFound:
             # Make a new Collection.
             collection, is_new = get_one_or_create(_db, Collection, name=name)
             if not is_new and collection.protocol != protocol:

--- a/model/configuration.py
+++ b/model/configuration.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from enum import Enum
 
 from flask_babel import lazy_gettext as _
-from sqlalchemy import Column, ForeignKey, Index, Integer, Unicode, UniqueConstraint
+from sqlalchemy import Column, ForeignKey, Index, Integer, Unicode
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session

--- a/model/contributor.py
+++ b/model/contributor.py
@@ -390,7 +390,6 @@ class Contributor(Base):
     @classmethod
     def _default_names(cls, name, default_display_name=None):
         name = name or ""
-        original_name = name
         """Split out from default_names to make it easy to test."""
         display_name = default_display_name
         # "Little, Brown &amp; Co." => "Little, Brown & Co."

--- a/model/credential.py
+++ b/model/credential.py
@@ -3,7 +3,6 @@
 import datetime
 import uuid
 
-import sqlalchemy
 from sqlalchemy import (
     Column,
     DateTime,

--- a/model/customlist.py
+++ b/model/customlist.py
@@ -3,7 +3,6 @@
 
 import logging
 from functools import total_ordering
-from pdb import set_trace
 
 from sqlalchemy import (
     Boolean,
@@ -188,7 +187,6 @@ class CustomList(Base):
 
             # There's no guarantee this Edition _has_ a work, so don't
             # filter by Work when looking for a duplicate.
-            kwargs = dict()
 
         if existing_entries:
             # There is a book equivalent to this one on the list.

--- a/model/edition.py
+++ b/model/edition.py
@@ -140,7 +140,6 @@ class Edition(Base, EditionConstants):
         etc. However it happens, your name only shows up once on the
         front of the book.
         """
-        seen_authors = set()
         primary_author = None
         other_authors = []
         acceptable_substitutes = defaultdict(list)
@@ -616,7 +615,6 @@ class Edition(Base, EditionConstants):
 
     def calculate_presentation(self, policy=None):
         """Make sure the presentation of this Edition is up-to-date."""
-        _db = Session.object_session(self)
         changed = False
         if policy is None:
             policy = PresentationCalculationPolicy()

--- a/model/hasfulltablecache.py
+++ b/model/hasfulltablecache.py
@@ -39,7 +39,7 @@ class HasFullTableCache(object):
                 cache[key] = obj
             if id_cache != cls.RESET:
                 id_cache[id] = obj
-        except TypeError as e:
+        except TypeError:
             # The cache was reset in between the time we checked for a
             # reset and the time we tried to put an object in the
             # cache. Stop trying to mess with the cache.
@@ -78,7 +78,7 @@ class HasFullTableCache(object):
         if cache != cls.RESET:
             try:
                 obj = cache.get(cache_key)
-            except TypeError as e:
+            except TypeError:
                 # This shouldn't happen. Even if the actual cache was
                 # reset just now, we still have a copy of the 'old'
                 # cache which passed the 'cache != cls.RESET' test.

--- a/model/identifier.py
+++ b/model/identifier.py
@@ -304,7 +304,7 @@ class Identifier(Base, IdentifierConstants):
                     identifier_details[urn] = (type, identifier)
                 else:
                     failures.append(urn)
-            except ValueError as e:
+            except ValueError:
                 failures.append(urn)
 
         identifiers_by_urn = dict()
@@ -666,7 +666,6 @@ class Identifier(Base, IdentifierConstants):
         """
         _db = Session.object_session(self)
         # Turn the subject type and identifier into a Subject.
-        classifications = []
         subject, is_new = Subject.lookup(
             _db,
             subject_type,
@@ -695,7 +694,7 @@ class Identifier(Base, IdentifierConstants):
                 subject=subject,
                 data_source=data_source,
             )
-        except MultipleResultsFound as e:
+        except MultipleResultsFound:
             # TODO: This is a hack.
             all_classifications = _db.query(Classification).filter(
                 Classification.identifier == self,
@@ -874,7 +873,6 @@ class Identifier(Base, IdentifierConstants):
         better to get rid of this hack and create real Works where we
         would be using this method.
         """
-        id = self.urn
         cover_image = None
         description = None
         most_recent_update = None

--- a/model/integrationclient.py
+++ b/model/integrationclient.py
@@ -1,7 +1,6 @@
 # encoding: utf-8
 # IntegrationClient
 
-import os
 import re
 
 from sqlalchemy import Boolean, Column, DateTime, Integer, Unicode

--- a/model/library.py
+++ b/model/library.py
@@ -23,7 +23,6 @@ from ..config import Configuration
 from ..entrypoint import EntryPoint
 from ..facets import FacetConstants
 from . import Base, get_one
-from .circulationevent import CirculationEvent
 from .edition import Edition
 from .hasfulltablecache import HasFullTableCache
 from .licensing import LicensePool
@@ -295,7 +294,7 @@ class Library(Base, HasFullTableCache):
 
         try:
             value = setting.json_value
-        except ValueError as e:
+        except ValueError:
             logging.error(
                 "Invalid list of enabled facets for %s: %s", group_name, setting.value
             )

--- a/model/listeners.py
+++ b/model/listeners.py
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 import datetime
-from pdb import set_trace
 from threading import RLock
 
 from sqlalchemy import event, text
@@ -9,7 +8,7 @@ from sqlalchemy.orm.base import NO_VALUE
 from sqlalchemy.orm.session import Session
 
 from ..config import Configuration
-from ..util.datetime_helpers import to_utc, utc_now
+from ..util.datetime_helpers import utc_now
 from . import Base
 from .admin import Admin, AdminRole
 from .classification import Genre
@@ -275,7 +274,7 @@ def licensepool_deleted(mapper, connection, target):
     """
     work = target.work
     if work:
-        record = work.external_index_needs_updating()
+        work.external_index_needs_updating()
 
 
 @event.listens_for(LicensePool.collection_id, "set")

--- a/model/patron.py
+++ b/model/patron.py
@@ -221,8 +221,6 @@ class Patron(Base):
         return [loan.work for loan in self.loans if loan.work]
 
     def works_on_loan_or_on_hold(self):
-        db = Session.object_session(self)
-        results = set()
         holds = [hold.work for hold in self.holds if hold.work]
         loans = self.works_on_loan()
         return set(holds + loans)

--- a/model/resource.py
+++ b/model/resource.py
@@ -832,7 +832,6 @@ class Representation(Base, MediaTypes):
                 # An optional function passed to raise errors if the
                 # post response isn't worth caching.
                 response_reviewer((status_code, headers, content))
-            exception = None
             media_type = cls._best_media_type(url, headers, presumed_media_type)
             if isinstance(content, str):
                 content = content.encode("utf8")
@@ -1015,7 +1014,7 @@ class Representation(Base, MediaTypes):
             try:
                 content = self.content.decode(encoding)
                 break
-            except UnicodeDecodeError as e:
+            except UnicodeDecodeError:
                 pass
         return content
 
@@ -1421,13 +1420,13 @@ class Representation(Base, MediaTypes):
 
         try:
             image.thumbnail(*args)
-        except IOError as e:
+        except IOError:
             # I'm not sure why, but sometimes just trying
             # it again works.
             original_exception = traceback.format_exc()
             try:
                 image.thumbnail(*args)
-            except IOError as e:
+            except IOError:
                 self.scale_exception = original_exception
                 self.scaled_at = None
                 return self, False
@@ -1439,7 +1438,7 @@ class Representation(Base, MediaTypes):
             image = image.convert("RGB")
         try:
             image.save(output, pil_format)
-        except Exception as e:
+        except Exception:
             self.scale_exception = traceback.format_exc()
             self.scaled_at = None
             # This most likely indicates a problem during the fetch phase,

--- a/model/work.py
+++ b/model/work.py
@@ -951,8 +951,6 @@ class Work(Base):
         if policy.classify or policy.choose_summary or policy.calculate_quality:
             # Find all related IDs that might have associated descriptions,
             # classifications, or measurements.
-            _db = Session.object_session(self)
-
             direct_identifier_ids = self._direct_identifier_ids
             all_identifier_ids = self.all_identifier_ids(policy=policy)
         else:
@@ -1165,7 +1163,6 @@ class Work(Base):
     def calculate_marc_record(self):
         from ..marc import Annotator, MARCExporter
 
-        _db = Session.object_session(self)
         record = MARCExporter.create_record(
             self, annotator=Annotator, force_create=True
         )
@@ -1204,7 +1201,6 @@ class Work(Base):
 
         :return: A WorkCoverageRecord.
         """
-        _db = Session.object_session(self)
         record, is_new = WorkCoverageRecord.add_for(
             self, operation=operation, status=CoverageRecord.REGISTERED
         )
@@ -1917,7 +1913,7 @@ class Work(Base):
                 from ..external_search import ExternalSearchIndex
 
                 search_index = ExternalSearchIndex(_db)
-            except CannotLoadConfiguration as e:
+            except CannotLoadConfiguration:
                 # No search index is configured. This is fine -- just skip that part.
                 pass
         if search_index is not None:

--- a/monitor.py
+++ b/monitor.py
@@ -245,7 +245,6 @@ class Monitor(object):
         """Do any work that needs to be done at the end, once the main work
         has completed successfully.
         """
-        pass
 
 
 class TimelineMonitor(Monitor):
@@ -448,7 +447,6 @@ class SweepMonitor(CollectionMonitor):
         timestamp = self.timestamp()
         offset = timestamp.counter
         new_offset = offset
-        exception = None
 
         # The timestamp for a SweepMonitor is purely informative --
         # we're not trying to capture all the events that happened
@@ -460,7 +458,6 @@ class SweepMonitor(CollectionMonitor):
 
         total_processed = 0
         while True:
-            old_offset = offset
             batch_started_at = utc_now()
             new_offset, batch_size = self.process_batch(offset)
             total_processed += batch_size
@@ -755,7 +752,6 @@ class MakePresentationReadyMonitor(NotPresentationReadyWorkSweepMonitor):
         if not edition:
             work = work.calculate_presentation()
         identifier = edition.primary_identifier
-        overall_success = True
         failures = []
         for provider in self.coverage_providers:
             covered_types = provider.input_identifier_types
@@ -1030,7 +1026,6 @@ class ScrubberMonitor(ReaperMonitor):
 
     def run_once(self, *args, **kwargs):
         """Find all rows that need to be scrubbed, and scrub them."""
-        rows_scrubbed = 0
         cls = self.MODEL_CLASS
         update = (
             cls.__table__.update()

--- a/opds.py
+++ b/opds.py
@@ -133,7 +133,6 @@ class Annotator(object):
             # available to people using this application.
             avail = active_license_pool.availability_time
             if avail:
-                now = utc_now()
                 today = datetime.date.today()
                 if isinstance(avail, datetime.datetime):
                     avail = avail.date()
@@ -166,7 +165,6 @@ class Annotator(object):
         """Make any custom modifications necessary to integrate this
         OPDS feed into the application's workflow.
         """
-        pass
 
     @classmethod
     def group_uri(cls, work, license_pool, identifier):
@@ -204,7 +202,6 @@ class Annotator(object):
         thumbnails = []
         full = []
         if work:
-            _db = Session.object_session(work)
             if work.cover_thumbnail_url:
                 thumbnails = [cdnify(work.cover_thumbnail_url)]
 
@@ -1298,7 +1295,7 @@ class AcquisitionFeed(OPDSFeed):
                 force_create,
                 use_cache,
             )
-        except UnfulfillableWork as e:
+        except UnfulfillableWork:
             logging.info(
                 "Work %r is not fulfillable, refusing to create an <entry>.",
                 work,
@@ -1382,15 +1379,11 @@ class AcquisitionFeed(OPDSFeed):
             edition = work.presentation_edition
 
         # Find the .epub link
-        epub_href = None
-        p = None
 
         links = []
-        cover_quality = 0
         qualities = []
         if work:
             qualities.append(("Work quality", work.quality))
-        full_url = None
 
         thumbnail_urls, full_urls = self.annotator.cover_links(work)
         for rel, urls in (
@@ -1741,8 +1734,6 @@ class AcquisitionFeed(OPDSFeed):
         # Generate a list of licensing tags. These should be inserted
         # into a <link> tag.
         tags = []
-        availability_tag_name = None
-        suppress_since = False
         status = None
         since = None
         until = None
@@ -1909,7 +1900,7 @@ class LookupAcquisitionFeed(AcquisitionFeed):
             edition = work.presentation_edition
         try:
             return self._create_entry(work, active_licensepool, edition, identifier)
-        except UnfulfillableWork as e:
+        except UnfulfillableWork:
             logging.info(
                 "Work %r is not fulfillable, refusing to create an <entry>.", work
             )

--- a/opds_import.py
+++ b/opds_import.py
@@ -76,8 +76,6 @@ def parse_identifier(db, identifier):
 class AccessNotAuthenticated(Exception):
     """No authentication is configured for this service"""
 
-    pass
-
 
 class SimplifiedOPDSLookup(object):
     """Tiny integration class for the Simplified 'lookup' protocol."""
@@ -191,15 +189,14 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup, HasSelfTests):
            SelfTestResult objects.
         """
         lookup_class = lookup_class or MetadataWranglerOPDSLookup
-        results = dict()
 
         # Find all eligible Collections on the system, instantiate a
         # _new_ MetadataWranglerOPDSLookup for each, and call
         # its _run_collection_self_tests method.
         for c in _db.query(Collection):
             try:
-                metadata_identifier = c.metadata_identifier
-            except ValueError as e:
+                c.metadata_identifier
+            except ValueError:
                 continue
 
             lookup = lookup_class.from_config(_db, c)
@@ -212,10 +209,9 @@ class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup, HasSelfTests):
         """
         if not self.collection:
             return
-        metadata_identifier = None
         try:
-            metadata_identifier = self.collection.metadata_identifier
-        except ValueError as e:
+            self.collection.metadata_identifier
+        except ValueError:
             # This collection has no metadata identifier. It's
             # probably a "Manual intervention" collection. It cannot
             # interact with the metadata wrangler and there's no need
@@ -838,7 +834,7 @@ class OPDSImporter(object):
                     pools[key] = pool
                 if work:
                     works[key] = work
-            except Exception as e:
+            except Exception:
                 identifier, ignore = Identifier.parse_urn(self._db, key)
                 data_source = self.data_source
                 failure = CoverageFailure(
@@ -1009,7 +1005,6 @@ class OPDSImporter(object):
 
         # Use one loop for both, since the id will be the same for both dictionaries.
         metadata = {}
-        circulationdata = {}
         for id, m_data_dict in list(fp_metadata.items()):
             xml_data_dict = xml_data_meta.get(id, {})
 
@@ -1140,7 +1135,6 @@ class OPDSImporter(object):
         information that allows a patron to actually get a book
         that's not open access.
         """
-        pass
 
     @classmethod
     def combine(self, d1, d2):
@@ -1289,7 +1283,7 @@ class OPDSImporter(object):
         try:
             kwargs_meta = cls._data_detail_for_feedparser_entry(entry, data_source)
             return identifier, kwargs_meta, None
-        except Exception as e:
+        except Exception:
             _db = Session.object_session(data_source)
             identifier_obj, ignore = Identifier.parse_urn(_db, identifier)
             failure = CoverageFailure(
@@ -1487,7 +1481,7 @@ class OPDSImporter(object):
         urn = message.urn
         try:
             identifier, ignore = Identifier.parse_urn(_db, urn)
-        except ValueError as e:
+        except ValueError:
             identifier = None
 
         if not identifier:
@@ -1543,7 +1537,7 @@ class OPDSImporter(object):
             )
             return identifier, data, None
 
-        except Exception as e:
+        except Exception:
             _db = Session.object_session(data_source)
             identifier_obj, ignore = Identifier.parse_urn(_db, identifier)
             failure = CoverageFailure(
@@ -1614,7 +1608,7 @@ class OPDSImporter(object):
             default = datetime_utc(utc_now().year, 1, 1)
             try:
                 data["published"] = dateutil.parser.parse(date_string, default=default)
-            except Exception as e:
+            except Exception:
                 # This entry had an issued tag, but it was in a format we couldn't parse.
                 pass
 
@@ -1722,7 +1716,7 @@ class OPDSImporter(object):
         weight = attr.get("{http://schema.org/}ratingValue", default_weight)
         try:
             weight = int(weight)
-        except ValueError as e:
+        except ValueError:
             weight = default_weight
 
         return SubjectData(type=subject_type, identifier=term, name=name, weight=weight)

--- a/problem_details.py
+++ b/problem_details.py
@@ -1,6 +1,6 @@
 from flask_babel import lazy_gettext as _
 
-from .util.http import INTEGRATION_ERROR
+from .util.http import INTEGRATION_ERROR  # noqa
 from .util.problem_detail import ProblemDetail as pd
 
 # Generic problem detail documents that recapitulate HTTP errors.

--- a/scripts.py
+++ b/scripts.py
@@ -10,7 +10,6 @@ import unicodedata
 import uuid
 from collections import defaultdict
 from enum import Enum
-from pdb import set_trace
 
 from sqlalchemy import and_, exists, text
 from sqlalchemy.exc import ProgrammingError
@@ -113,7 +112,7 @@ class Script(object):
                 try:
                     parsed = strptime_utc(time_string, full_format)
                     return parsed
-                except ValueError as e:
+                except ValueError:
                     continue
         raise ValueError("Could not parse time: %s" % time_string)
 
@@ -158,7 +157,6 @@ class Script(object):
         :param exception: A stack trace for the exception, if any,
            that stopped the script from running.
         """
-        pass
 
 
 class TimestampScript(Script):
@@ -524,7 +522,7 @@ class IdentifierInputScript(InputScript):
             if identifier_type == cls.DATABASE_ID:
                 try:
                     arg = int(arg)
-                except ValueError as e:
+                except ValueError:
                     # We'll print out a warning later.
                     arg = None
                 if arg:
@@ -2431,7 +2429,6 @@ class DatabaseMigrationScript(Script):
         """Run each migration, first by timestamp and then by directory
         priority.
         """
-        previous = None
 
         def raise_error(migration_path, message, code=1):
             print()
@@ -2449,7 +2446,6 @@ class DatabaseMigrationScript(Script):
                     try:
                         self._run_migration(full_migration_path, timestamp)
                         self._db.commit()
-                        previous = migration_file
                     except SystemExit as se:
                         if se.code:
                             raise_error(
@@ -2488,7 +2484,7 @@ class DatabaseMigrationScript(Script):
 
                 if ok_to_execute:
                     if transactionless:
-                        new_session = self._run_migration_without_transaction(sql)
+                        self._run_migration_without_transaction(sql)
                     elif one_tx_per_statement:
                         commands = self._extract_statements_from_sql_file(
                             migration_path
@@ -2786,7 +2782,7 @@ class CheckContributorNamesInDB(IdentifierInputScript):
 
         contributor = contribution.contributor
 
-        identifier = contribution.edition.primary_identifier
+        contribution.edition.primary_identifier
 
         if contributor.sort_name and contributor.display_name:
             computed_sort_name_local_new = unicodedata.normalize(

--- a/testing.py
+++ b/testing.py
@@ -1,4 +1,3 @@
-import inspect
 import json
 import logging
 import os
@@ -7,12 +6,9 @@ import tempfile
 import time
 import uuid
 from datetime import timedelta
-from pdb import set_trace
 
 import mock
 import pytest
-from psycopg2.errors import UndefinedTable
-from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm.session import Session
 
 from . import external_search
@@ -21,7 +17,6 @@ from .config import Configuration
 from .coverage import (
     BibliographicCoverageProvider,
     CollectionCoverageProvider,
-    CoverageFailure,
     IdentifierCoverageProvider,
     WorkCoverageProvider,
 )
@@ -56,9 +51,7 @@ from .model import (
     LicensePool,
     LicensePoolDeliveryMechanism,
     Patron,
-    PresentationCalculationPolicy,
     Representation,
-    Resource,
     RightsStatus,
     SessionManager,
     Subject,
@@ -387,9 +380,7 @@ class DatabaseTest(object):
             data_source_name = DataSource.GUTENBERG
         if fiction is None:
             fiction = True
-        new_edition = False
         if not presentation_edition:
-            new_edition = True
             presentation_edition = self._edition(
                 title=title,
                 language=language,
@@ -1640,7 +1631,6 @@ class MockRequestsResponse(object):
         """Null implementation of raise_for_status, a method
         implemented by real requests Response objects.
         """
-        pass
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/classifiers/test_bic.py
+++ b/tests/classifiers/test_bic.py
@@ -1,5 +1,5 @@
 from ... import classifier
-from ...classifier import *
+from ...classifier import Classifier
 from ...classifier.bic import BICClassifier as BIC
 
 

--- a/tests/classifiers/test_bisac.py
+++ b/tests/classifiers/test_bisac.py
@@ -1,5 +1,3 @@
-import re
-
 import pytest
 
 from ...classifier import BISACClassifier, Classifier
@@ -9,7 +7,6 @@ from ...classifier.bisac import (
     anything,
     fiction,
     juvenile,
-    m,
     nonfiction,
     something,
     ya,

--- a/tests/classifiers/test_classifier.py
+++ b/tests/classifiers/test_classifier.py
@@ -24,7 +24,7 @@ from ...classifier.keyword import FASTClassifier as FAST
 from ...classifier.keyword import LCSHClassifier as LCSH
 from ...classifier.lcc import LCCClassifier as LCC
 from ...classifier.simplified import SimplifiedGenreClassifier
-from ...model import Classification, DataSource, Genre, Subject
+from ...model import DataSource, Genre, Subject
 from ...testing import DatabaseTest
 
 genres = dict()
@@ -614,7 +614,6 @@ class TestWorkClassifier(DatabaseTest):
         # This book will be not classified as a comic book, because
         # the "comic books" classification does not come from its
         # license source.
-        source = self.work.license_pools[0].data_source
         oclc = DataSource.lookup(self._db, DataSource.OCLC)
         self.identifier.classify(oclc, Subject.TAG, "Comic Books", weight=100)
         self.classifier.add(self.identifier.classifications[0])
@@ -684,7 +683,6 @@ class TestWorkClassifier(DatabaseTest):
         assert lower[5] == upper[8]
 
         # And this affects the target age we choose.
-        a = self.classifier.target_age(Classifier.AUDIENCE_CHILDREN)
         assert (5, 8) == self.classifier.target_age(Classifier.AUDIENCE_CHILDREN)
 
     def test_target_age_errs_towards_wider_span(self):
@@ -733,7 +731,6 @@ class TestWorkClassifier(DatabaseTest):
         historical_romance = self._genre(classifier.Historical_Romance)
         romance = self._genre(classifier.Romance)
         romantic_suspense = self._genre(classifier.Romantic_Suspense)
-        nonfiction_genre = self._genre(classifier.History)
 
         self.classifier.genre_weights[romance] = 100
 

--- a/tests/classifiers/test_ddc.py
+++ b/tests/classifiers/test_ddc.py
@@ -1,5 +1,5 @@
 from ... import classifier
-from ...classifier import *
+from ...classifier import Classifier
 from ...classifier.ddc import DeweyDecimalClassifier as DDC
 
 
@@ -16,7 +16,6 @@ class TestDewey(object):
     def test_audience(self):
 
         child = Classifier.AUDIENCE_CHILDREN
-        adult = Classifier.AUDIENCE_ADULT
         young_adult = Classifier.AUDIENCE_YOUNG_ADULT
 
         def aud(identifier):

--- a/tests/classifiers/test_keyword.py
+++ b/tests/classifiers/test_keyword.py
@@ -1,6 +1,5 @@
 from ... import classifier
-from ...classifier import *
-from ...classifier.keyword import FASTClassifier as FAST
+from ...classifier import Classifier
 from ...classifier.keyword import KeywordBasedClassifier as Keyword
 from ...classifier.keyword import LCSHClassifier as LCSH
 

--- a/tests/classifiers/test_lcc.py
+++ b/tests/classifiers/test_lcc.py
@@ -1,14 +1,9 @@
-from ... import classifier
-from ...classifier import *
+from ...classifier import Classifier
 from ...classifier.lcc import LCCClassifier as LCC
 
 
 class TestLCC(object):
     def test_name_for(self):
-
-        child = Classifier.AUDIENCE_CHILDREN
-        adult = Classifier.AUDIENCE_ADULT
-
         assert "LANGUAGE AND LITERATURE" == LCC.name_for("P")
         assert "English literature" == LCC.name_for("PR")
         assert "Fiction and juvenile belles lettres" == LCC.name_for("PZ")
@@ -18,8 +13,6 @@ class TestLCC(object):
 
     def test_audience(self):
         child = Classifier.AUDIENCE_CHILDREN
-        adult = Classifier.AUDIENCE_ADULT
-        young_adult = Classifier.AUDIENCE_YOUNG_ADULT
 
         def aud(identifier):
             return LCC.audience(LCC.scrub_identifier(identifier), None)

--- a/tests/classifiers/test_overdrive.py
+++ b/tests/classifiers/test_overdrive.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-from ...classifier import *
+from ...classifier import Classifier
 from ...classifier.overdrive import OverdriveClassifier as Overdrive
 
 

--- a/tests/classifiers/test_simplified.py
+++ b/tests/classifiers/test_simplified.py
@@ -1,5 +1,4 @@
-from ... import classifier
-from ...classifier import *
+from ...classifier import *  # noqa
 
 
 class TestSimplifiedGenreClassifier(object):

--- a/tests/models/test_cachedfeed.py
+++ b/tests/models/test_cachedfeed.py
@@ -4,10 +4,8 @@ import datetime
 import pytest
 
 from ...classifier import Classifier
-from ...lane import Facets, Lane, Pagination, WorkList
+from ...lane import Facets, Pagination, WorkList
 from ...model.cachedfeed import CachedFeed
-from ...model.configuration import ConfigurationSetting
-from ...opds import AcquisitionFeed
 from ...testing import DatabaseTest
 from ...util.datetime_helpers import utc_now
 from ...util.flask_util import OPDSFeedResponse
@@ -396,7 +394,6 @@ class TestCachedFeed(DatabaseTest):
         # If the Library associated with the WorkList used in the feed
         # has root lanes, `private` is always set to True, even if we
         # asked for the opposite.
-        from unittest.mock import PropertyMock, patch
 
         from ...model import Library
 

--- a/tests/models/test_circulationevent.py
+++ b/tests/models/test_circulationevent.py
@@ -10,7 +10,7 @@ from ...model.datasource import DataSource
 from ...model.identifier import Identifier
 from ...model.licensing import LicensePool
 from ...testing import DatabaseTest
-from ...util.datetime_helpers import datetime_utc, strptime_utc, to_utc, utc_now
+from ...util.datetime_helpers import datetime_utc, strptime_utc, utc_now
 
 
 class TestCirculationEvent(DatabaseTest):

--- a/tests/models/test_collection.py
+++ b/tests/models/test_collection.py
@@ -302,12 +302,11 @@ class TestCollection(DatabaseTest):
         assert 349 == self.collection.default_loan_period(client, audio)
 
         # The same value is used for other clients.
-        client2 = self._integration_client()
+        self._integration_client()
         assert 347 == self.collection.default_loan_period(client)
         assert 349 == self.collection.default_loan_period(client, audio)
 
     def test_default_reservation_period(self):
-        library = self._default_library
         # The default when no value is set.
         assert (
             Collection.STANDARD_DEFAULT_RESERVATION_PERIOD
@@ -360,7 +359,7 @@ class TestCollection(DatabaseTest):
         self.collection.external_integration.url = "url"
         self.collection.external_integration.username = "username"
         self.collection.external_integration.password = "password"
-        setting = self.collection.external_integration.set_setting("setting", "value")
+        self.collection.external_integration.set_setting("setting", "value")
 
         data = self.collection.explain()
         assert [

--- a/tests/models/test_configuration.py
+++ b/tests/models/test_configuration.py
@@ -326,7 +326,7 @@ class TestConfigurationSetting(DatabaseTest):
         ConfigurationSetting.sitewide(self._db, "a_secret").value = "1"
         ConfigurationSetting.sitewide(self._db, "nonsecret_setting").value = "2"
 
-        integration = self._external_integration("a protocol", "a goal")
+        self._external_integration("a protocol", "a goal")
 
         actual = ConfigurationSetting.explain(self._db, include_secrets=True)
         expect = """Site-wide configuration settings:

--- a/tests/models/test_credential.py
+++ b/tests/models/test_credential.py
@@ -316,8 +316,6 @@ class TestUniquenessConstraints(DatabaseTest):
     def test_duplicate_patron_credential(self):
         # A given patron can't have two global credentials with the same data
         # source and type.
-        patron = self._patron()
-
         c1 = Credential(
             data_source=self.data_source, type=self.type, patron=self.patron
         )

--- a/tests/models/test_customlist.py
+++ b/tests/models/test_customlist.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from pdb import set_trace
 
 import pytest
 

--- a/tests/models/test_edition.py
+++ b/tests/models/test_edition.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-import datetime
 
 from ...model import PresentationCalculationPolicy, get_one_or_create
 from ...model.constants import MediaTypes
@@ -32,11 +31,10 @@ class TestEdition(DatabaseTest):
 
     def test_license_pools(self):
         # Here are two collections that provide access to the same book.
-        c1 = self._collection()
-        c2 = self._collection()
+        other_collection = self._collection()
 
         edition, lp1 = self._edition(with_license_pool=True)
-        lp2 = self._licensepool(edition=edition, collection=c2)
+        lp2 = self._licensepool(edition=edition, collection=other_collection)
 
         # Two LicensePools for the same work.
         assert lp1.identifier == lp2.identifier
@@ -106,10 +104,10 @@ class TestEdition(DatabaseTest):
         )
 
         # One of them has coverage from OCLC Classify
-        c1 = self._coverage_record(g1, oclc)
+        self._coverage_record(g1, oclc)
 
         # The other has coverage from a specific operation on OCLC Classify
-        c2 = self._coverage_record(g2, oclc, "some operation")
+        self._coverage_record(g2, oclc, "some operation")
 
         # Here's a web record, just sitting there.
         w, ignore = Edition.for_foreign_id(

--- a/tests/models/test_identifier.py
+++ b/tests/models/test_identifier.py
@@ -162,9 +162,6 @@ class TestIdentifier(DatabaseTest):
         # already exist.
         isbn_urn = "urn:isbn:9781453219539"
         urns = [new_urn, isbn_urn]
-        only_overdrive = [Identifier.OVERDRIVE_ID]
-        only_isbn = [Identifier.OVERDRIVE_ID]
-        everything = []
 
         success, failure = Identifier.parse_urns(
             self._db, urns, allowed_types=[Identifier.OVERDRIVE_ID]
@@ -269,7 +266,7 @@ class TestIdentifier(DatabaseTest):
         level_4_equivalent = self._identifier()
         level_3_equivalent.equivalent_to(data_source, level_4_equivalent, 0.6)
 
-        unrelated = self._identifier()
+        self._identifier()  # Unrelated identifier
 
         # With a low threshold and enough levels, we find all the identifiers.
         high_levels_low_threshold = PresentationCalculationPolicy(
@@ -519,10 +516,10 @@ class TestIdentifier(DatabaseTest):
         )
 
         # One of them has coverage from OCLC Classify
-        c1 = self._coverage_record(g1, oclc)
+        self._coverage_record(g1, oclc)
 
         # The other has coverage from a specific operation on OCLC Classify
-        c2 = self._coverage_record(g2, oclc, "some operation")
+        self._coverage_record(g2, oclc, "some operation")
 
         # Here's a web record, just sitting there.
         w, ignore = Edition.for_foreign_id(
@@ -596,8 +593,6 @@ class TestIdentifier(DatabaseTest):
 
     def test_missing_coverage_from_with_cutoff_date(self):
         gutenberg = DataSource.lookup(self._db, DataSource.GUTENBERG)
-        oclc = DataSource.lookup(self._db, DataSource.OCLC)
-        web = DataSource.lookup(self._db, DataSource.WEB)
 
         # Here's an Edition with a coverage record from OCLC classify.
         gutenberg, ignore = Edition.for_foreign_id(
@@ -709,7 +704,6 @@ class TestIdentifier(DatabaseTest):
         assert 2 == len(entry.links)
         assert any(filter(lambda l: l.href == "http://thumb", entry.links))
         # And the updated time has been changed accordingly.
-        expected = thumbnail.resource.representation.mirrored_at
         assert AtomFeed._strftime(even_later) == entry.updated
 
     @parameterized.expand(

--- a/tests/models/test_licensing.py
+++ b/tests/models/test_licensing.py
@@ -13,14 +13,12 @@ from ...model.collection import CollectionMissing
 from ...model.complaint import Complaint
 from ...model.constants import MediaTypes
 from ...model.contributor import Contributor
-from ...model.coverage import WorkCoverageRecord
 from ...model.datasource import DataSource
 from ...model.edition import Edition
 from ...model.identifier import Identifier
 from ...model.licensing import (
     DeliveryMechanism,
     Hold,
-    License,
     LicensePool,
     LicensePoolDeliveryMechanism,
     Loan,
@@ -189,13 +187,13 @@ class TestDeliveryMechanism(DatabaseTest):
         # for content_type and drm_scheme.
         with_drm_args = dict(content_type="type1", drm_scheme="scheme1")
         without_drm_args = dict(content_type="type1", drm_scheme=None)
-        with_drm = create(self._db, dm, **with_drm_args)
+        create(self._db, dm, **with_drm_args)
         pytest.raises(IntegrityError, create, self._db, dm, **with_drm_args)
         self._db.rollback()
 
         # You can't create two DeliveryMechanisms with the same value
         # for content_type and a null value for drm_scheme.
-        without_drm = create(self._db, dm, **without_drm_args)
+        create(self._db, dm, **without_drm_args)
         pytest.raises(IntegrityError, create, self._db, dm, **without_drm_args)
         self._db.rollback()
 
@@ -216,7 +214,7 @@ class TestRightsStatus(DatabaseTest):
 
     def test_unique_uri_constraint(self):
         # We already have this RightsStatus.
-        status = RightsStatus.lookup(self._db, RightsStatus.IN_COPYRIGHT)
+        RightsStatus.lookup(self._db, RightsStatus.IN_COPYRIGHT)
 
         # Let's try to create another one with the same URI.
         dupe = RightsStatus(uri=RightsStatus.IN_COPYRIGHT)
@@ -1147,7 +1145,6 @@ class TestLicensePool(DatabaseTest):
         yesterday = now - datetime.timedelta(days=1)
         tomorrow = now + datetime.timedelta(days=1)
 
-        fulfillment = pool.delivery_mechanisms[0]
         position = 99
         external_identifier = self._str
         hold, is_new = pool.on_hold_to(
@@ -1264,7 +1261,7 @@ class TestLicensePoolDeliveryMechanism(DatabaseTest):
 
         # Set it back to a URL that does not imply open access, and
         # the status of the LicensePool is changed back.
-        non_open_access_status = lpdm.set_rights_status(uri)
+        lpdm.set_rights_status(uri)
         assert False == pool.open_access
 
         # Now add a second delivery mechanism, so the pool has one

--- a/tests/models/test_measurement.py
+++ b/tests/models/test_measurement.py
@@ -308,7 +308,7 @@ class TestMeasurement(DatabaseTest):
         )
 
         # Now it's just so-so.
-        popularity = identifier.add_measurement(self.source, Measurement.POPULARITY, 59)
+        identifier.add_measurement(self.source, Measurement.POPULARITY, 59)
 
         # This measurement is irrelevant because "Test Data Source"
         # doesn't have a mapping from number of editions to a

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -1,18 +1,13 @@
 # encoding: utf-8
-import datetime
 
 import pytest
 from psycopg2.extras import NumericRange
 from sqlalchemy import not_
 from sqlalchemy.orm.exc import MultipleResultsFound
 
-from ... import classifier
 from ...config import Configuration
-from ...external_search import mock_search_index
 from ...model import (
-    DataSource,
     Edition,
-    Genre,
     SessionManager,
     Timestamp,
     get_one,

--- a/tests/models/test_patron.py
+++ b/tests/models/test_patron.py
@@ -36,7 +36,6 @@ class TestAnnotation(DatabaseTest):
         assert annotation.timestamp > yesterday
 
     def test_patron_annotations_are_descending(self):
-        pool1 = self._licensepool(None)
         pool2 = self._licensepool(None)
         patron = self._patron()
         annotation1, ignore = create(

--- a/tests/models/test_resource.py
+++ b/tests/models/test_resource.py
@@ -1113,7 +1113,6 @@ class TestCoverResource(DatabaseTest):
         images that are the wrong aspect ratio, or too small.
         """
 
-        ideal_ratio = Identifier.IDEAL_COVER_ASPECT_RATIO
         ideal_height = Identifier.IDEAL_IMAGE_HEIGHT
         ideal_width = Identifier.IDEAL_IMAGE_WIDTH
 

--- a/tests/models/test_work.py
+++ b/tests/models/test_work.py
@@ -992,9 +992,7 @@ class TestWork(DatabaseTest):
 
     def test_top_genre(self):
         work = self._work()
-        identifier = work.presentation_edition.primary_identifier
         genres = self._db.query(Genre).all()
-        source = DataSource.lookup(self._db, DataSource.AXIS_360)
 
         # returns None when work has no genres
         assert None == work.top_genre()
@@ -1032,7 +1030,7 @@ class TestWork(DatabaseTest):
 
         # Create a third Collection that's just hanging around, not
         # doing anything.
-        collection3 = self._collection()
+        self._collection()
 
         # These are the edition's authors.
         [contributor1] = [
@@ -1595,9 +1593,9 @@ class TestWork(DatabaseTest):
         assert [] == list(index.docs.values())
 
     def test_for_unchecked_subjects(self):
-
+        # Create two works
         w1 = self._work(with_license_pool=True)
-        w2 = self._work()
+        self._work()
         identifier = w1.license_pools[0].identifier
 
         # Neither of these works is associated with any subjects, so

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,7 +1,4 @@
-import json
-
 from ..analytics import Analytics
-from ..config import Configuration, temp_config
 from ..local_analytics_provider import LocalAnalyticsProvider
 from ..mock_analytics_provider import MockAnalyticsProvider
 from ..model import CirculationEvent, ExternalIntegration, Library, create, get_one

--- a/tests/test_app_server.py
+++ b/tests/test_app_server.py
@@ -76,7 +76,6 @@ class TestURNLookupHandler(DatabaseTest):
         in the feed.
         """
         [obj] = self.handler.precomposed_entries
-        expect = OPDSMessage(urn, code, message)
         assert isinstance(obj, OPDSMessage)
         assert urn == obj.urn
         assert code == obj.status_code

--- a/tests/test_circulation_data.py
+++ b/tests/test_circulation_data.py
@@ -5,25 +5,20 @@ import pytest
 
 from ..metadata_layer import (
     CirculationData,
-    ContributorData,
     FormatData,
     IdentifierData,
     LicenseData,
     LinkData,
     Metadata,
     ReplacementPolicy,
-    SubjectData,
 )
 from ..model import (
-    Collection,
     DataSource,
     DeliveryMechanism,
     Hyperlink,
     Identifier,
-    License,
     Representation,
     RightsStatus,
-    Subject,
 )
 from ..model.configuration import ExternalIntegrationLink
 from ..s3 import MockS3Uploader
@@ -75,8 +70,6 @@ class TestCirculationData(DatabaseTest):
         # Check that we didn't put something in the CirculationData that
         # will prevent it from being copied. (e.g., self.log)
 
-        subject = SubjectData(Subject.TAG, "subject")
-        contributor = ContributorData()
         identifier = IdentifierData(Identifier.GUTENBERG_ID, "1")
         link = LinkData(Hyperlink.OPEN_ACCESS_DOWNLOAD, "example.epub")
         format = FormatData(Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.NO_DRM)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ import os
 from sqlalchemy.orm.session import Session
 
 from ..config import Configuration as BaseConfiguration
-from ..model import ConfigurationSetting, ExternalIntegration
+from ..model import ExternalIntegration
 from ..testing import DatabaseTest
 
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -4,9 +4,7 @@ import pytest
 
 from ..coverage import (
     BaseCoverageProvider,
-    BibliographicCoverageProvider,
     CatalogCoverageProvider,
-    CollectionCoverageProvider,
     CoverageFailure,
     CoverageProviderProgress,
     IdentifierCoverageProvider,
@@ -27,13 +25,11 @@ from ..metadata_layer import (
     SubjectData,
 )
 from ..model import (
-    Collection,
     CollectionMissing,
     Contributor,
     CoverageRecord,
     DataSource,
     DeliveryMechanism,
-    Edition,
     ExternalIntegration,
     Hyperlink,
     Identifier,
@@ -493,7 +489,7 @@ class TestBaseCoverageProvider(CoverageProviderTest):
 
         # Let's register an identifier so that the method we're testing
         # will be called.
-        needs_coverage = self._identifier()
+        self._identifier()
         progress = provider.run_once(progress)
 
         # The numbers returned from process_batch_and_handle_results
@@ -1092,7 +1088,7 @@ class TestIdentifierCoverageProvider(CoverageProviderTest):
         provider = Mock1(self._db)
 
         # Here's a generic CoverageRecord for an identifier.
-        record1 = CoverageRecord.add_for(self.identifier, provider.data_source)
+        CoverageRecord.add_for(self.identifier, provider.data_source)
 
         # That record doesn't count for purposes of
         # items_that_need_coverage, because the CoverageRecord doesn't
@@ -1924,7 +1920,7 @@ class TestCatalogCoverageProvider(CoverageProviderTest):
         i2 = self._identifier()
         c2.catalog_identifier(i2)
 
-        i3 = self._identifier()
+        self._identifier()
 
         # This Identifier is licensed through the Collection c1, but
         # it's not in the catalog--catalogs are used for different
@@ -1936,7 +1932,6 @@ class TestCatalogCoverageProvider(CoverageProviderTest):
         class Provider(CatalogCoverageProvider):
             SERVICE_NAME = "test"
             DATA_SOURCE_NAME = DataSource.OVERDRIVE
-            pass
 
         provider = Provider(c1)
         assert [i1] == provider.items_that_need_coverage().all()

--- a/tests/test_equivalency.py
+++ b/tests/test_equivalency.py
@@ -1,13 +1,4 @@
-from ..model import (
-    CirculationEvent,
-    DataSource,
-    Edition,
-    Identifier,
-    LicensePool,
-    PresentationCalculationPolicy,
-    Work,
-    get_one_or_create,
-)
+from ..model import DataSource, Edition, Identifier, PresentationCalculationPolicy
 from ..testing import DatabaseTest
 
 

--- a/tests/test_external_list.py
+++ b/tests/test_external_list.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-import datetime
 
 from ..external_list import (
     ClassificationBasedMembershipManager,
@@ -8,7 +7,7 @@ from ..external_list import (
 )
 from ..model import DataSource, Edition, Identifier, Subject
 from ..testing import DatabaseTest, DummyMetadataClient
-from ..util.datetime_helpers import datetime_utc, strptime_utc, to_utc, utc_now
+from ..util.datetime_helpers import datetime_utc, strptime_utc, utc_now
 
 
 class TestCustomListFromCSV(DatabaseTest):

--- a/tests/test_external_search.py
+++ b/tests/test_external_search.py
@@ -1,9 +1,7 @@
 # encoding: utf-8
 import json
-import logging
 import re
 import time
-from collections import defaultdict
 
 import pytest
 from elasticsearch.exceptions import ElasticsearchException
@@ -29,7 +27,6 @@ from ..external_search import (
     CurrentMapping,
     ExternalSearchIndex,
     Filter,
-    Mapping,
     MockExternalSearchIndex,
     MockSearchResult,
     Query,
@@ -40,7 +37,7 @@ from ..external_search import (
     WorkSearchResult,
     mock_search_index,
 )
-from ..lane import Facets, FeaturedFacets, Lane, Pagination, SearchFacets, WorkList
+from ..lane import Facets, FeaturedFacets, Pagination, SearchFacets, WorkList
 from ..metadata_layer import ContributorData, IdentifierData
 from ..model import (
     ConfigurationSetting,
@@ -48,9 +45,7 @@ from ..model import (
     Contributor,
     DataSource,
     Edition,
-    ExternalIntegration,
     Genre,
-    Work,
     WorkCoverageRecord,
     get_one_or_create,
 )
@@ -1367,7 +1362,6 @@ class TestSearchOrder(EndToEndSearchTest):
             for pagination_class in (Pagination, SortKeyPagination):
                 pagination = pagination_class(size=1)
                 to_process = list(reversed(order)) + [[]]
-                results = []
                 pagination = SortKeyPagination(size=1)
                 while to_process:
                     filter = Filter(facets=facets, **filter_kwargs)
@@ -1486,7 +1480,7 @@ class TestAuthorFilter(EndToEndSearchTest):
     # person had an authorship role.
 
     def populate_works(self):
-        _work = self.default_work
+        self.default_work
 
         # Create a number of Contributor objects--some fragmentary--
         # representing the same person.
@@ -3082,7 +3076,7 @@ class TestFilter(DatabaseTest):
     def test_constructor(self):
         # Verify that the Filter constructor sets members with
         # minimal processing.
-        collection = self._default_collection
+        self._default_collection
 
         media = object()
         languages = object()

--- a/tests/test_lane.py
+++ b/tests/test_lane.py
@@ -6,8 +6,7 @@ import random
 import pytest
 from elasticsearch.exceptions import ElasticsearchException
 from mock import MagicMock, call
-from sqlalchemy import and_, func, text
-from sqlalchemy.sql.elements import Case
+from sqlalchemy import and_, text
 
 from ..classifier import Classifier
 from ..config import Configuration
@@ -39,17 +38,13 @@ from ..lane import (
 )
 from ..model import (
     CachedFeed,
-    CustomListEntry,
     DataSource,
     Edition,
     Genre,
-    Identifier,
     Library,
     LicensePool,
-    SessionManager,
     Work,
     WorkGenre,
-    dump_query,
     get_one_or_create,
     tuple_to_numericrange,
 )
@@ -265,7 +260,6 @@ class TestFacetsWithEntryPoint(DatabaseTest):
         # be passing this in to load_entrypoint every time.
         entrypoints = [audio, ebooks]
 
-        worklist = object()
         m = FacetsWithEntryPoint.load_entrypoint
 
         # This request does not ask for any particular entrypoint, and
@@ -2128,7 +2122,6 @@ class TestWorkList(DatabaseTest):
     def test_groups(self):
         w1 = MockWork(1)
         w2 = MockWork(2)
-        w3 = MockWork(3)
 
         class MockWorkList(object):
             def __init__(self, works):
@@ -3423,7 +3416,7 @@ class TestLane(DatabaseTest):
         lane = self._lane()
         child_lane = self._lane(parent=lane)
         grandchild_lane = self._lane(parent=child_lane)
-        unrelated = self._lane()
+        self._lane()  # Unrelated lane
         worklist.sublanes = [child_lane]
 
         # A WorkList has no parentage.
@@ -3598,7 +3591,7 @@ class TestLane(DatabaseTest):
         # has *two* sets of restrictions: a book must be on both
         # the staff picks list *and* the best sellers list.
         staff_picks_lane.inherit_parent_restrictions = True
-        x = staff_picks_lane.inherited_values("customlists")
+        staff_picks_lane.inherited_values("customlists")
         assert sorted([[staff_picks], [best_sellers]]) == sorted(
             staff_picks_lane.inherited_values("customlists")
         )
@@ -4212,7 +4205,6 @@ class TestWorkListGroupsEndToEnd(EndToEndSearchTest):
         # There are no audiobooks in the system, so passing in a
         # FeaturedFacets scoped to the AudiobooksEntryPoint excludes everything.
         facets = FeaturedFacets(0, entrypoint=AudiobooksEntryPoint)
-        _db = self._db
         assert [] == list(fiction.groups(self._db, facets=facets))
 
         # Here's an entry point that applies a language filter

--- a/tests/test_local_analytics_provider.py
+++ b/tests/test_local_analytics_provider.py
@@ -3,7 +3,7 @@ import pytest
 from ..local_analytics_provider import LocalAnalyticsProvider
 from ..model import CirculationEvent, ExternalIntegration, create
 from ..testing import DatabaseTest
-from ..util.datetime_helpers import to_utc, utc_now
+from ..util.datetime_helpers import utc_now
 
 
 class TestLocalAnalyticsProvider(DatabaseTest):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -12,7 +12,6 @@ from ..log import (
     CloudwatchLogs,
     JSONFormatter,
     LogConfiguration,
-    Logger,
     Loggly,
     LogglyHandler,
     StringFormatter,
@@ -31,7 +30,7 @@ class TestJSONFormatter(object):
         # Cause an exception so we can capture its exc_info()
         try:
             raise ValueError("fake exception")
-        except ValueError as e:
+        except ValueError:
             exc_info = sys.exc_info()
 
         record = logging.LogRecord(

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -1,5 +1,4 @@
 import datetime
-from io import StringIO
 from urllib.parse import quote
 
 import pytest
@@ -25,7 +24,7 @@ from ..model import (
     Work,
     get_one,
 )
-from ..s3 import MockS3Uploader, S3Uploader
+from ..s3 import MockS3Uploader
 from ..testing import DatabaseTest
 from ..util.datetime_helpers import datetime_utc, utc_now
 
@@ -572,7 +571,7 @@ class TestMARCExporter(DatabaseTest):
         assert record.as_marc() == new_record.as_marc()
 
     def test_records(self):
-        integration = self._integration()
+        self._integration()
         now = utc_now()
         exporter = MARCExporter.from_config(self._default_library)
         annotator = Annotator()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -39,7 +39,7 @@ from ..model import (
 from ..model.configuration import ExternalIntegrationLink
 from ..s3 import MockS3Uploader
 from ..testing import DatabaseTest, DummyHTTPClient, DummyMetadataClient
-from ..util.datetime_helpers import datetime_utc, strptime_utc, to_utc, utc_now
+from ..util.datetime_helpers import datetime_utc, strptime_utc, utc_now
 from ..util.http import RemoteIntegrationException
 
 
@@ -108,8 +108,8 @@ class TestMetadataImporter(DatabaseTest):
         source2 = DataSource.lookup(self._db, DataSource.METADATA_WRANGLER)
         edition = self._edition()
         identifier = edition.primary_identifier
-        c1 = identifier.classify(source1, Subject.TAG, "i will persist")
-        c2 = identifier.classify(source2, Subject.TAG, "i will perish")
+        identifier.classify(source1, Subject.TAG, "i will persist")
+        identifier.classify(source2, Subject.TAG, "i will perish")
 
         # Now we get some new metadata from source #2.
         subjects = [SubjectData(type=Subject.TAG, identifier="i will conquer")]

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-import re
 import xml.etree.ElementTree as ET
 from io import StringIO
 
@@ -304,7 +303,6 @@ class TestAnnotators(DatabaseTest):
         work.rating = 0.6
         work.calculate_opds_entries(verbose=True)
         feed = AcquisitionFeed(self._db, self._str, self._url, [work], VerboseAnnotator)
-        url = self._url
         tag = feed.create_entry(work, None)
 
         nsmap = dict(schema="http://schema.org/")
@@ -596,11 +594,11 @@ class TestOPDS(DatabaseTest):
         facet_links = self.links(by_title, AcquisitionFeed.FACET_REL)
 
         library = self._default_library
-        order_facets = library.enabled_facets(Facets.ORDER_FACET_GROUP_NAME)
+        library.enabled_facets(Facets.ORDER_FACET_GROUP_NAME)
         availability_facets = library.enabled_facets(
             Facets.AVAILABILITY_FACET_GROUP_NAME
         )
-        collection_facets = library.enabled_facets(Facets.COLLECTION_FACET_GROUP_NAME)
+        library.enabled_facets(Facets.COLLECTION_FACET_GROUP_NAME)
 
         def link_for_facets(facets):
             return [x for x in facet_links if facets.query_string in x["href"]]
@@ -630,7 +628,6 @@ class TestOPDS(DatabaseTest):
         today_s = today.strftime("%Y-%m-%d")
         the_past = today - datetime.timedelta(days=2)
         the_past_s = the_past.strftime("%Y-%m-%d")
-        the_past_time = the_past.strftime(AtomFeed.TIME_FORMAT_NAIVE)
         the_distant_past = today - datetime.timedelta(days=100)
         the_distant_past_s = the_distant_past.strftime(AtomFeed.TIME_FORMAT_NAIVE)
         the_future = today + datetime.timedelta(days=2)
@@ -1356,7 +1353,6 @@ class TestOPDS(DatabaseTest):
         # The feed has no breadcrumb links, since we're not
         # searching the lane -- just using some aspects of the lane
         # to guide the search.
-        parentage = list(fantasy_lane.parentage)
         root = ET.fromstring(feed)
         breadcrumbs = root.find("{%s}breadcrumbs" % AtomFeed.SIMPLIFIED_NS)
         assert None == breadcrumbs
@@ -1479,9 +1475,6 @@ class TestAcquisitionFeed(DatabaseTest):
         """Verify that add_entrypoint_links calls _entrypoint_link
         on every EntryPoint passed in.
         """
-        m = AcquisitionFeed.add_entrypoint_links
-
-        old_entrypoint_link = AcquisitionFeed._entrypoint_link
 
         class Mock(object):
             attrs = dict(href="the response")
@@ -1770,7 +1763,6 @@ class TestAcquisitionFeed(DatabaseTest):
         # This work's OPDS entry was created with a namespace map
         # that did not include the drm: namespace.
         work.simple_opds_entry = "<entry><foo>bar</foo></entry>"
-        pool = work.license_pools[0]
 
         # But now the annotator is set up to insert a tag with that
         # namespace.
@@ -1979,9 +1971,6 @@ class TestAcquisitionFeed(DatabaseTest):
             feed = MockFeed()
             annotator = TestAnnotator()
 
-            entrypoint = add_breadcrumbs_kwargs.get("entrypoint", None)
-            include_lane = add_breadcrumbs_kwargs.get("include_lane", False)
-
             feed.add_breadcrumbs(lane, **add_breadcrumbs_kwargs)
 
             if not expect_breadcrumbs_for:
@@ -2014,7 +2003,6 @@ class TestAcquisitionFeed(DatabaseTest):
             # trickier, mainly because the URLs change once an
             # entrypoint is selected.
             previous_breadcrumb_url = None
-            actual_urls = []
 
             for i, crumb in enumerate(crumbs):
                 expect = expect_breadcrumbs_for[i]
@@ -2322,7 +2310,7 @@ class TestLookupAcquisitionFeed(DatabaseTest):
         # Even if the Identifier does have a Work, if the Works don't
         # match, we get the same error.
         edition, lp = self._edition(with_license_pool=True)
-        work2 = lp.calculate_work()
+        lp.calculate_work()
         feed, entry = self.entry(lp.identifier, work)
         assert entry == OPDSMessage(
             lp.identifier.urn, 500, expect_error % lp.identifier.urn
@@ -2377,7 +2365,6 @@ class TestLookupAcquisitionFeed(DatabaseTest):
         work = self._work(with_license_pool=True)
         work.verbose_opds_entry = "<entry>Cached</entry>"
         [pool1] = work.license_pools
-        identifier1 = pool1.identifier
 
         collection2 = self._collection()
         edition2 = self._edition()

--- a/tests/test_opds_import.py
+++ b/tests/test_opds_import.py
@@ -1,20 +1,17 @@
 import datetime
 import os
-import pkgutil
 import random
 from io import StringIO
 from urllib.parse import quote
 
-import feedparser
 import pytest
 from lxml import etree
 from psycopg2.extras import NumericRange
 
-from ..config import CannotLoadConfiguration, IntegrationException
+from ..config import IntegrationException
 from ..coverage import CoverageFailure
-from ..metadata_layer import CirculationData, LinkData, Metadata, TimestampData
+from ..metadata_layer import CirculationData, LinkData, Metadata
 from ..model import (
-    Collection,
     Contributor,
     CoverageRecord,
     DataSource,
@@ -29,7 +26,6 @@ from ..model import (
     RightsStatus,
     Subject,
     Work,
-    WorkCoverageRecord,
 )
 from ..model.configuration import ExternalIntegrationLink
 from ..opds_import import (
@@ -38,7 +34,6 @@ from ..opds_import import (
     OPDSImporter,
     OPDSImportMonitor,
     OPDSXMLParser,
-    SimplifiedOPDSLookup,
 )
 from ..s3 import MockS3Uploader, S3Uploader, S3UploaderConfiguration
 from ..selftest import SelfTestResult
@@ -193,7 +188,7 @@ class TestMetadataWranglerOPDSLookup(OPDSTest):
 
         # Ensure there are two collections: one with a metadata
         # identifier and one without.
-        no_unique_id = self._default_collection
+        self._default_collection
         with_unique_id = self.collection
         with_unique_id.external_account_id = "unique id"
 
@@ -367,7 +362,7 @@ class TestMetadataWranglerOPDSLookup(OPDSTest):
         response = mock_response(
             url, auth, 200, self.sample_opds("metadata_wrangler_overdrive.opds")
         )
-        results = m(test_result, response)
+        m(test_result, response)
         assert [
             "Request URL: %s" % url,
             "Request authorization: %s" % auth,
@@ -530,7 +525,6 @@ class TestOPDSImporter(OPDSImporterTest):
         book_2 = metadata.get("urn:isbn:9781468316438")
         assert book_2 != None
         # Verify if id was add in the end of identifier
-        book_2_identifiers = book_2.identifiers
         found = False
         for entry in book_2.identifiers:
             if entry.identifier == "https://root.uri/2":
@@ -541,7 +535,6 @@ class TestOPDSImporter(OPDSImporterTest):
         book_3 = metadata.get("urn:isbn:9781683351993")
         assert book_2 != None
         # Verify if id was add in the end of identifier
-        book_3_identifiers = book_3.identifiers
         expected_identifier = [
             "9781683351993",
             "https://root.uri/3",
@@ -1566,7 +1559,6 @@ class TestOPDSImporter(OPDSImporterTest):
 
         # The work's presentation edition has been chosen.
         work.calculate_presentation()
-        op = WorkCoverageRecord.CHOOSE_EDITION_OPERATION
 
         # But we're about to find out a new title for the book.
         i = edition.primary_identifier
@@ -2221,8 +2213,6 @@ class TestMirroring(OPDSImporterTest):
         # If we fetch the feed again, and the entries have been updated since the
         # cutoff, but the content of the open access links hasn't changed, we won't mirror
         # them again.
-        cutoff = datetime_utc(2013, 1, 2, 16, 56, 40)
-
         http.queue_response(
             epub10441["url"], 304, media_type=Representation.EPUB_MEDIA_TYPE
         )

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -1,5 +1,4 @@
 from ..classifier import Classifier
-from ..lane import Lane
 from ..model import Genre
 from ..opensearch import OpenSearchDocument
 from ..testing import DatabaseTest

--- a/tests/test_overdrive.py
+++ b/tests/test_overdrive.py
@@ -1,7 +1,6 @@
 # encoding: utf-8
 import json
 import os
-import pkgutil
 
 import pytest
 
@@ -9,7 +8,6 @@ from ..config import CannotLoadConfiguration
 from ..coverage import CoverageFailure
 from ..metadata_layer import LinkData
 from ..model import (
-    Collection,
     Contributor,
     DeliveryMechanism,
     Edition,
@@ -30,7 +28,7 @@ from ..overdrive import (
 )
 from ..scripts import RunCollectionCoverageProviderScript
 from ..testing import DatabaseTest, MockRequestsResponse
-from ..util.http import HTTP, BadResponseException
+from ..util.http import BadResponseException
 from ..util.string_helpers import base64
 
 

--- a/tests/test_personal_names.py
+++ b/tests/test_personal_names.py
@@ -1,24 +1,6 @@
 # encoding: utf-8
-import datetime
-import os
-import re
-import site
-import sys
-import tempfile
-from io import StringIO
 
-from ..mock_analytics_provider import MockAnalyticsProvider
-from ..model import (
-    Contributor,
-    DataSource,
-    Edition,
-    Identifier,
-    Work,
-    create,
-    get_one,
-    get_one_or_create,
-)
-from ..testing import DatabaseTest, DummyHTTPClient
+from ..testing import DatabaseTest
 from ..util.personal_names import display_name_to_sort_name
 
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,6 +1,5 @@
 import os
 import random
-import shutil
 import stat
 import tempfile
 from io import StringIO
@@ -86,7 +85,7 @@ from ..testing import (
     AlwaysSuccessfulWorkCoverageProvider,
     DatabaseTest,
 )
-from ..util.datetime_helpers import datetime_utc, strptime_utc, to_utc, utc_now
+from ..util.datetime_helpers import datetime_utc, strptime_utc, utc_now
 from ..util.worker_pools import DatabasePool
 
 
@@ -1376,8 +1375,6 @@ class TestDatabaseMigrationScript(DatabaseMigrationScriptTest):
 
         # There are two temporary files in tmp_path, confirming that the test
         # Python files created by the migrations fixture were run.
-        test_dir = os.path.split(__file__)[0]
-        all_files = os.listdir(test_dir)
         test_generated_files = sorted(
             [
                 f.name
@@ -1502,7 +1499,6 @@ class TestDatabaseMigrationInitializationScript(DatabaseMigrationScriptTest):
         assert 7 == script.overall_timestamp.counter
 
         # When forced, the counter can be reset on an existing timestamp.
-        previous_timestamp = script.overall_timestamp.finish
         script.run(["--last-run-date", "20121212", "--last-run-counter", "2", "-f"])
         expected_stamp = strptime_utc("20121212", "%Y%m%d")
         assert expected_stamp == script.overall_timestamp.finish
@@ -2223,8 +2219,6 @@ class MockOPDSImportMonitor(object):
 class MockOPDSImporter(object):
     """Pretend to import titles from an OPDS feed."""
 
-    pass
-
 
 class MockOPDSImportScript(OPDSImportScript):
     """Actually instantiate a monitor that will pretend to do something."""
@@ -2480,7 +2474,6 @@ class TestWhereAreMyBooksScript(DatabaseTest):
         # This work is not presentation-ready.
         work = self._work(with_license_pool=True)
         work.presentation_ready = False
-        script = MockWhereAreMyBooks(self._db)
         self.check_explanation(presentation_ready=0, not_presentation_ready=1)
 
     def test_no_delivery_mechanisms(self):
@@ -2503,7 +2496,6 @@ class TestWhereAreMyBooksScript(DatabaseTest):
         self.check_explanation(not_owned=1)
 
     def test_search_engine(self):
-        output = StringIO()
         search = MockExternalSearchIndex()
         work = self._work(with_license_pool=True)
         work.presentation_ready = True
@@ -3039,34 +3031,22 @@ class TestUpdateCustomListSizeScript(DatabaseTest):
 class TestWorkConsolidationScript(object):
     """TODO"""
 
-    pass
-
 
 class TestWorkPresentationScript(object):
     """TODO"""
-
-    pass
 
 
 class TestWorkClassificationScript(object):
     """TODO"""
 
-    pass
-
 
 class TestWorkOPDSScript(object):
     """TODO"""
-
-    pass
 
 
 class TestCustomListManagementScript(object):
     """TODO"""
 
-    pass
-
 
 class TestNYTBestSellerListsScript(object):
     """TODO"""
-
-    pass

--- a/tests/util/test_datetime_helpers.py
+++ b/tests/util/test_datetime_helpers.py
@@ -1,5 +1,4 @@
 import datetime
-from pdb import set_trace
 
 import pytest
 import pytz

--- a/tests/util/test_http.py
+++ b/tests/util/test_http.py
@@ -25,7 +25,7 @@ class TestHTTP(object):
 
     def test_request_with_timeout_success(self):
 
-        called_with = None
+        pass
 
         def fake_200_response(*args, **kwargs):
             # The HTTP method and URL are passed in the order
@@ -136,7 +136,6 @@ class TestHTTP(object):
             m(url, fake_200_response, disallowed_response_codes=["2xx"])
         except Exception as e:
             exc = e
-            pass
         assert exc is not None
 
         debug_doc = exc.as_problem_detail_document(debug=True)

--- a/tests/util/test_opds_writer.py
+++ b/tests/util/test_opds_writer.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 
 import pytz
 from lxml import etree

--- a/tests/util/test_string_helpers.py
+++ b/tests/util/test_string_helpers.py
@@ -5,7 +5,6 @@ import base64 as stdlib_base64
 import re
 
 import pytest
-from parameterized import parameterized
 
 from ...util.string_helpers import UnicodeAwareBase64, base64, random_string
 

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -376,7 +376,7 @@ class TestMedian(object):
 
 class TestFastQueryCount(DatabaseTest):
     def test_no_distinct(self):
-        identifier = self._identifier()
+        self._identifier()
         qu = self._db.query(Identifier)
         assert 1 == fast_query_count(qu)
 

--- a/tests/util/test_worker_pools.py
+++ b/tests/util/test_worker_pools.py
@@ -1,17 +1,8 @@
 import threading
-from contextlib import contextmanager
 
 from ...model import Identifier, SessionManager
 from ...testing import DatabaseTest
-from ...util.worker_pools import (
-    DatabaseJob,
-    DatabasePool,
-    DatabaseWorker,
-    Job,
-    Pool,
-    Queue,
-    Worker,
-)
+from ...util.worker_pools import DatabaseJob, DatabasePool, Pool, Queue, Worker
 
 
 class TestPool(object):

--- a/tests/util/test_xml_parser.py
+++ b/tests/util/test_xml_parser.py
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-from lxml.etree import XMLSyntaxError
 
 from ...util.xmlparser import XMLParser
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = isort, black, py{36,37,38,39}-docker
+envlist = isort, black, autoflake, py{36,37,38,39}-docker
 skipsdist = true
 
 [testenv]
@@ -55,6 +55,29 @@ deps         = {[testenv:black]deps}
 commands_pre =
 commands     = {[testenv:black]commands}
 
+[testenv:autoflake]
+description = Run autoflake (linter)
+skip_install = True
+deps = autoflake==1.4
+setenv = AUTOFLAKE_ARGS=--check
+commands_pre =
+commands =
+    autoflake \
+    --recursive \
+    --expand-star-imports \
+    --remove-all-unused-imports \
+    --remove-unused-variables \
+    --remove-duplicate-keys \
+    {env:AUTOFLAKE_ARGS:} .
+
+[testenv:autoflake-reformat]
+description = {[testenv:autoflake]description} and reformat
+skip_install = {[testenv:autoflake]skip_install}
+deps = {[testenv:autoflake]deps}
+setenv = AUTOFLAKE_ARGS=-i
+commands_pre = {[testenv:autoflake]commands_pre}
+commands = {[testenv:autoflake]commands}
+
 [testenv:flake8]
 description = Run Flake8 (linter)
 skip_install = True
@@ -99,3 +122,7 @@ python =
 [flake8]
 max-line-length = 120
 extend-ignore = E203, E501, E711, E712
+
+[isort]
+profile = black
+known_first_party = core,api

--- a/user_profile.py
+++ b/user_profile.py
@@ -2,7 +2,11 @@ import json
 
 from flask_babel import lazy_gettext as _
 
-from .problem_details import *
+from .problem_details import (
+    INTERNAL_SERVER_ERROR,
+    INVALID_INPUT,
+    UNSUPPORTED_MEDIA_TYPE,
+)
 
 
 class ProfileController(object):
@@ -42,7 +46,7 @@ class ProfileController(object):
             )
         try:
             body = json.dumps(profile_document)
-        except Exception as e:
+        except Exception:
             return INTERNAL_SERVER_ERROR.with_debug(
                 _("Could not convert profile document to JSON: %r.")
                 % (profile_document)
@@ -62,7 +66,7 @@ class ProfileController(object):
             return UNSUPPORTED_MEDIA_TYPE.detailed(_("Expected %s") % self.MEDIA_TYPE)
         try:
             profile_document = json.loads(body)
-        except Exception as e:
+        except Exception:
             return INVALID_INPUT.detailed(
                 _("Submitted profile document was not valid JSON.")
             )

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -13,7 +13,7 @@ from sqlalchemy.sql.functions import func
 
 # For backwards compatibility, import items that were moved to
 # languages.py
-from .languages import LanguageCodes, LookupTable
+from .languages import LanguageCodes, LookupTable  # noqa
 
 
 def batch(iterable, size=1):

--- a/util/epub.py
+++ b/util/epub.py
@@ -1,7 +1,4 @@
 import contextlib
-import logging
-import os
-import sys
 from io import BytesIO
 from zipfile import ZipFile
 

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -3,7 +3,6 @@ import datetime
 import time
 from wsgiref.handlers import format_date_time
 
-import flask
 from flask import Response as FlaskResponse
 from lxml import etree
 

--- a/util/opds_writer.py
+++ b/util/opds_writer.py
@@ -1,8 +1,6 @@
 import datetime
-import logging
 
 import pytz
-from flask import Response
 from lxml import builder, etree
 
 from .datetime_helpers import utc_now

--- a/util/permanent_work_id.py
+++ b/util/permanent_work_id.py
@@ -1,5 +1,4 @@
 import re
-import struct
 import unicodedata
 from hashlib import md5
 

--- a/util/string_helpers.py
+++ b/util/string_helpers.py
@@ -5,7 +5,6 @@
 import base64 as stdlib_base64
 import binascii
 import os
-import sys
 
 
 class UnicodeAwareBase64(object):

--- a/util/summary.py
+++ b/util/summary.py
@@ -143,7 +143,7 @@ class SummaryEvaluator(object):
 
         try:
             sentences = len(blob.sentences)
-        except Exception as e:
+        except Exception:
             # Can't parse into sentences for whatever reason.
             # Make a really bad guess.
             sentences = summary.count(". ") + 1

--- a/util/worker_pools.py
+++ b/util/worker_pools.py
@@ -1,7 +1,6 @@
 import logging
-from contextlib import contextmanager
 from queue import Queue
-from threading import RLock, Thread, settrace
+from threading import Thread
 
 # Much of the work in this file is based on
 # https://github.com/shazow/workerpool, with
@@ -153,11 +152,9 @@ class Job(object):
 
     def rollback(self, *args, **kwargs):
         """Cleans up the task if it errors"""
-        pass
 
     def finalize(self, *args, **kwargs):
         """Finalizes the task if it is successful"""
-        pass
 
     def do_run(self):
         """Does the work"""

--- a/util/xmlparser.py
+++ b/util/xmlparser.py
@@ -1,5 +1,3 @@
-import re
-import sys
 from io import BytesIO
 
 from lxml import etree


### PR DESCRIPTION
Add [autoflake](https://pypi.org/project/autoflake/#description) to our linting step to check for: 
- unused variables
- star imports
- unused imports

There were some imports flagged that were necessary, so I marked them with `# noqa` so that autoflake ignores them.
 
This PR adds it to our tox configuration, and automatically runs it with github actions. Like the other linters, it has two options to run it though tox `tox -e autoflake` that just does the linting, and `tox -e autoflake-reformat` that does the reformatting step.