### PR TITLE
Show lcp:hashed_passphrase only for LCP DRM-protected items

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -18,15 +18,11 @@ from .lane import (
     Pagination,
     SearchFacets,
 )
-from .lcp.credential import LCPCredentialFactory
-from .lcp.exceptions import LCPError
 from .model import (
     CachedFeed,
     Contributor,
     DataSource,
-    DeliveryMechanism,
     Edition,
-    ExternalIntegration,
     Hyperlink,
     Identifier,
     Measurement,
@@ -1690,46 +1686,6 @@ class AcquisitionFeed(OPDSFeed):
             indirect_types = []
         link = cls.link(rel, href, initial_type)
         indirect = cls.indirect_acquisition(indirect_types)
-
-        # In the case of LCP we have to include a patron's hashed passphrase
-        # inside the acquisition link so client applications can use it to bypass authentication
-        # and will not ask patrons to enter their passphrases
-        # For more information please look here:
-        # https://readium.org/lcp-specs/notes/lcp-key-retrieval.html#including-a-hashed-passphrase-in-an-opds-1-catalog
-        if (
-            active_loan
-            and active_loan.license_pool.collection.protocol
-            in [
-                ExternalIntegration.LCP,
-                ExternalIntegration.ODL,
-                ExternalIntegration.ODL2,
-            ]
-            and (
-                (
-                    active_loan.fulfillment
-                    and active_loan.fulfillment.delivery_mechanism
-                    and active_loan.fulfillment.delivery_mechanism
-                    == DeliveryMechanism.LCP_DRM
-                )
-                or initial_type == DeliveryMechanism.LCP_DRM
-            )
-        ):
-            db = Session.object_session(active_loan)
-            lcp_credential_factory = LCPCredentialFactory()
-
-            try:
-                hashed_passphrase = lcp_credential_factory.get_hashed_passphrase(
-                    db, active_loan.patron
-                )
-                hashed_passphrase_element = AtomFeed.makeelement(
-                    "{%s}hashed_passphrase" % AtomFeed.LCP_NS
-                )
-                hashed_passphrase_element.text = hashed_passphrase
-
-                link.append(hashed_passphrase_element)
-            except LCPError:
-                # The patron's passphrase wasn't generated yet and not present in the database.
-                pass
 
         if indirect is not None:
             link.append(indirect)

--- a/opds.py
+++ b/opds.py
@@ -24,6 +24,7 @@ from .model import (
     CachedFeed,
     Contributor,
     DataSource,
+    DeliveryMechanism,
     Edition,
     ExternalIntegration,
     Hyperlink,
@@ -1695,11 +1696,24 @@ class AcquisitionFeed(OPDSFeed):
         # and will not ask patrons to enter their passphrases
         # For more information please look here:
         # https://readium.org/lcp-specs/notes/lcp-key-retrieval.html#including-a-hashed-passphrase-in-an-opds-1-catalog
-        if active_loan and active_loan.license_pool.collection.protocol in [
-            ExternalIntegration.LCP,
-            ExternalIntegration.ODL,
-            ExternalIntegration.ODL2,
-        ]:
+        if (
+            active_loan
+            and active_loan.license_pool.collection.protocol
+            in [
+                ExternalIntegration.LCP,
+                ExternalIntegration.ODL,
+                ExternalIntegration.ODL2,
+            ]
+            and (
+                (
+                    active_loan.fulfillment
+                    and active_loan.fulfillment.delivery_mechanism
+                    and active_loan.fulfillment.delivery_mechanism
+                    == DeliveryMechanism.LCP_DRM
+                )
+                or initial_type == DeliveryMechanism.LCP_DRM
+            )
+        ):
             db = Session.object_session(active_loan)
             lcp_credential_factory = LCPCredentialFactory()
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1,11 +1,9 @@
 import datetime
 import logging
-import re
 import xml.etree.ElementTree as ET
 from io import StringIO
 
 import feedparser
-import pytest
 from flask_babel import lazy_gettext as _
 from lxml import etree
 from psycopg2.extras import NumericRange
@@ -27,7 +25,6 @@ from ..entrypoint import (
 from ..external_search import MockExternalSearchIndex
 from ..facets import FacetConstants
 from ..lane import Facets, FeaturedFacets, Pagination, SearchFacets, WorkList
-from ..lcp.credential import LCPCredentialFactory
 from ..model import (
     CachedFeed,
     Contributor,


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds additional logic to ensure that `lcp:hashed_passphrase` is shown only for LCP DRM-protected items.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
