### PR TITLE
Refactor Analytics to singleton.

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -1,14 +1,14 @@
-import contextlib
 import importlib
-import os
+import logging
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Set
 
 from sqlalchemy.orm.session import Session
 
 from .config import CannotLoadConfiguration
 from .model import ExternalIntegration
 from .util.datetime_helpers import utc_now
+from .util.log import log_elapsed_time
 
 
 class Analytics:
@@ -21,6 +21,7 @@ class Analytics:
     """
 
     _singleton_instance = None
+    log = logging.getLogger("Analytics manager")
 
     GLOBAL_ENABLED = None
     LIBRARY_ENABLED: Set[int] = set()
@@ -31,6 +32,7 @@ class Analytics:
             refresh = True
             instance = super().__new__(cls)
             cls._singleton_instance = instance
+            cls.log.info("Set singleton instance.")
         if refresh:
             instance._initialize_instance(_db)
         return instance
@@ -38,8 +40,10 @@ class Analytics:
     @classmethod
     def _reset_singleton_instance(cls):
         """Reset the singleton instance. Primarily used for tests."""
+        cls.log.info("Resetting singleton instance (should be used only for tests).")
         cls._singleton_instance = None
 
+    @log_elapsed_time(log_method=log.info, message_prefix="Initializing instance")
     def _initialize_instance(self, _db):
         """Initialize an instance (usually the singleton) of the class.
 
@@ -59,15 +63,16 @@ class Analytics:
         # Turn each integration into an analytics provider.
         for integration in integrations:
             module = integration.protocol
+            libraries = integration.libraries
             try:
                 provider_class = self._provider_class_from_module(module)
                 if provider_class:
-                    if not integration.libraries:
+                    if not libraries:
                         provider = provider_class(integration)
                         sitewide_providers.append(provider)
                         global_enabled = True
                     else:
-                        for library in integration.libraries:
+                        for library in libraries:
                             provider = provider_class(integration, library)
                             library_providers[library.id].append(provider)
                             library_enabled.add(library.id)
@@ -75,6 +80,11 @@ class Analytics:
                     initialization_exceptions[integration.id] = (
                         "Module %s does not have Provider defined." % module
                     )
+                self.log.info("Provider {provider!r} for protocol {protocol!r} has {scope} scope.".format(
+                    protocol=module,
+                    provider=provider_class.__name__,
+                    scope=f"per-library ({len(libraries)})" if libraries else "site-wide",
+                ))
             except (ImportError, CannotLoadConfiguration) as e:
                 initialization_exceptions[integration.id] = e
 

--- a/analytics.py
+++ b/analytics.py
@@ -2,6 +2,7 @@ import contextlib
 import importlib
 import os
 from collections import defaultdict
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from sqlalchemy.orm.session import Session
 
@@ -10,17 +11,46 @@ from .model import ExternalIntegration
 from .util.datetime_helpers import utc_now
 
 
-class Analytics(object):
+class Analytics:
+    """Loads configuration and dispatches methods for analytics providers.
+
+    SINGLETON!! Only one instance is meant to exist at any given time.
+
+    Configuration is loaded only on the first instantiation or when
+    `refresh=True` is passed in to facilitate reload.
+    """
+
+    _singleton_instance = None
 
     GLOBAL_ENABLED = None
-    LIBRARY_ENABLED = set()
+    LIBRARY_ENABLED: Set[int] = set()
 
-    def __init__(self, _db):
-        self.sitewide_providers = []
-        self.library_providers = defaultdict(list)
-        self.initialization_exceptions = {}
-        Analytics.GLOBAL_ENABLED = False
-        Analytics.LIBRARY_ENABLED = set()
+    def __new__(cls, _db, refresh=False) -> "Analytics":
+        instance = cls._singleton_instance
+        if instance is None:
+            refresh = True
+            instance = super().__new__(cls)
+            cls._singleton_instance = instance
+        if refresh:
+            instance._initialize_instance(_db)
+        return instance
+
+    @classmethod
+    def _reset_singleton_instance(cls):
+        """Reset the singleton instance. Primarily used for tests."""
+        cls._singleton_instance = None
+
+    def _initialize_instance(self, _db):
+        """Initialize an instance (usually the singleton) of the class.
+
+        We don't use __init__ because it would be run whether or not
+        a new instance were instantiated.
+        """
+        sitewide_providers = []
+        library_providers = defaultdict(list)
+        initialization_exceptions: Dict[int, Exception] = {}
+        global_enabled = False
+        library_enabled = set()
         # Find a list of all the ExternalIntegrations set up with a
         # goal of analytics.
         integrations = _db.query(ExternalIntegration).filter(
@@ -28,34 +58,40 @@ class Analytics(object):
         )
         # Turn each integration into an analytics provider.
         for integration in integrations:
-            kwargs = {}
             module = integration.protocol
-            if module.startswith("."):
-                # This is a relative import. Import it relative to
-                # this module. This should only happen during tests.
-                kwargs["package"] = __name__
-            else:
-                # This is an absolute import. Trust sys.path to find it.
-                pass
             try:
-                provider_module = importlib.import_module(module, **kwargs)
-                provider_class = getattr(provider_module, "Provider", None)
+                provider_class = self._provider_class_from_module(module)
                 if provider_class:
                     if not integration.libraries:
                         provider = provider_class(integration)
-                        self.sitewide_providers.append(provider)
-                        Analytics.GLOBAL_ENABLED = True
+                        sitewide_providers.append(provider)
+                        global_enabled = True
                     else:
                         for library in integration.libraries:
                             provider = provider_class(integration, library)
-                            self.library_providers[library.id].append(provider)
-                            Analytics.LIBRARY_ENABLED.add(library.id)
+                            library_providers[library.id].append(provider)
+                            library_enabled.add(library.id)
                 else:
-                    self.initialization_exceptions[integration.id] = (
+                    initialization_exceptions[integration.id] = (
                         "Module %s does not have Provider defined." % module
                     )
             except (ImportError, CannotLoadConfiguration) as e:
-                self.initialization_exceptions[integration.id] = e
+                initialization_exceptions[integration.id] = e
+
+        # update the instance variables all at once
+        self.sitewide_providers = sitewide_providers
+        self.library_providers = library_providers
+        self.initialization_exceptions = initialization_exceptions
+        Analytics.GLOBAL_ENABLED = global_enabled
+        Analytics.LIBRARY_ENABLED = library_enabled
+
+    @classmethod
+    def _provider_class_from_module(cls, module: str) -> Any:
+        # Relative imports, which should be configured only during testing, are
+        # relative to this module. sys.path will handle the absolute imports.
+        import_kwargs = {"package": __name__} if module.startswith(".") else {}
+        provider_module = importlib.import_module(module, **import_kwargs)
+        return getattr(provider_module, "Provider", None)
 
     def collect_event(self, library, license_pool, event_type, time=None, **kwargs):
         if not time:

--- a/analytics.py
+++ b/analytics.py
@@ -80,11 +80,15 @@ class Analytics:
                     initialization_exceptions[integration.id] = (
                         "Module %s does not have Provider defined." % module
                     )
-                self.log.info("Provider {provider!r} for protocol {protocol!r} has {scope} scope.".format(
-                    protocol=module,
-                    provider=provider_class.__name__,
-                    scope=f"per-library ({len(libraries)})" if libraries else "site-wide",
-                ))
+                self.log.info(
+                    "Provider {provider!r} for protocol {protocol!r} has {scope} scope.".format(
+                        protocol=module,
+                        provider=provider_class.__name__,
+                        scope=f"per-library ({len(libraries)})"
+                        if libraries
+                        else "site-wide",
+                    )
+                )
             except (ImportError, CannotLoadConfiguration) as e:
                 initialization_exceptions[integration.id] = e
 

--- a/local_analytics_provider.py
+++ b/local_analytics_provider.py
@@ -111,4 +111,5 @@ class LocalAnalyticsProvider(object):
         return local_analytics
 
 
+# The Analytics class looks for the name "Provider".
 Provider = LocalAnalyticsProvider

--- a/mock_analytics_provider.py
+++ b/mock_analytics_provider.py
@@ -13,4 +13,5 @@ class MockAnalyticsProvider(object):
         self.time = time
 
 
+# The Analytics class looks for the name "Provider".
 Provider = MockAnalyticsProvider

--- a/testing.py
+++ b/testing.py
@@ -16,6 +16,7 @@ from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm.session import Session
 
 from . import external_search
+from .analytics import Analytics
 from .classifier import Classifier
 from .config import Configuration
 from .coverage import (
@@ -224,6 +225,9 @@ class DatabaseTest(object):
         ExternalIntegration.reset_cache()
         Genre.reset_cache()
         Library.reset_cache()
+
+        # Reset the Analytics singleton between tests.
+        Analytics._reset_singleton_instance()
 
         # Also roll back any record of those changes in the
         # Configuration instance.

--- a/util/log.py
+++ b/util/log.py
@@ -1,0 +1,20 @@
+import functools
+import time
+from typing import Callable
+
+
+def log_elapsed_time(*, log_method: Callable, message_prefix: str = None):
+    prefix = f"{message_prefix}: " if message_prefix else ""
+
+    def outer(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            log_method(f"{prefix}Starting...")
+            tic = time.perf_counter()
+            value = fn(*args, **kwargs)
+            toc = time.perf_counter()
+            elapsed_time = toc - tic
+            log_method(f"{prefix}Completed. (elapsed time: {elapsed_time:0.4f} seconds)")
+            return value
+        return wrapper
+    return outer

--- a/util/log.py
+++ b/util/log.py
@@ -14,7 +14,11 @@ def log_elapsed_time(*, log_method: Callable, message_prefix: str = None):
             value = fn(*args, **kwargs)
             toc = time.perf_counter()
             elapsed_time = toc - tic
-            log_method(f"{prefix}Completed. (elapsed time: {elapsed_time:0.4f} seconds)")
+            log_method(
+                f"{prefix}Completed. (elapsed time: {elapsed_time:0.4f} seconds)"
+            )
             return value
+
         return wrapper
+
     return outer


### PR DESCRIPTION
## Description

- Refactors `Analytics` to a singleton class.
- Moves a `LocalAnalyticsProvider` test to the expected file.
- Enables a test that has not been running for the last couple of years because the `LocalAnalyticsProvider` test had the same name and had been included in the same test class.
- Attempts to make it as obvious as possible that `Aanlytics` is a singleton, since this is not a common pattern in Python and may be confusing to some developers.

NB: I didn't address the `GLOBAL_ENABLED` and `LIBRARY_ENABLED` class variables this time around because I was mostly focused on the performance issues and there would've been more code/tests to sort out. These should be addressed at some point when we have a little more time, as they could eventually cause confusion or even problems.

## Motivation and Context

The primary purpose of this branch is to improve the performance of Analytics initialization and, by extension that of the  circulation manager in general) initialization by converting `Analytics` to a singleton class. This allows us to avoid updating the various call sites, while reducing the number of initializations to one, regardless of the number of times it is called.

## How Has This Been Tested?

- Manual testing in my local development environment.
- New tests related to the singleton nature of `Analytics`, including the need to force reload in some cases.

## Checklist:

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
